### PR TITLE
Possible solution for #229

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -24,10 +24,13 @@
 
 # -- General configuration ------------------------------------------------
 
+import recommonmark
+
 
 # Enable use of markdown
 
 from recommonmark.parser import CommonMarkParser
+from recommonmark.transform import AutoStructify
 
 source_parsers = {
     '.md': CommonMarkParser,
@@ -212,3 +215,8 @@ texinfo_documents = [
 
 
 
+def setup(app):
+    app.add_config_value('recommonmark_config', {
+        'enable_eval_rst': True
+            }, True)
+    app.add_transform(AutoStructify)

--- a/conf.py
+++ b/conf.py
@@ -39,8 +39,6 @@ source_parsers = {
 source_suffix = ['.rst', '.md']
 
 
-
-
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
@@ -86,7 +84,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'drafts']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'drafts', 'email_templates', 'data']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/email_templates/inviting_new_maintainers.md
+++ b/email_templates/inviting_new_maintainers.md
@@ -1,0 +1,35 @@
+Subject: Invitation to become a Carpentry Maintainer
+CC: Existing Maintainers for the repo and other new Maintainer applicants for the same repo.
+
+Hi all,
+
+Thank you for applying to become a Maintainer for {lesson name and link to
+repo}. We're excited to have you on the Maintainer team! Your co-Maintainers are
+cc'd here.
+
+As a Maintainer, you’re part of a team that is responsible for ensuring that
+your lesson materials stay up-to-date, accurate, functional and cohesive. You’ll
+monitor your lesson repository, make sure that PRs and Issues are addressed in a
+timely manner, and participate in the lesson development cycle including lesson
+releases. {Add a sentence about when the next lesson release is scheduled for.}
+
+The new Maintainers for all of the Carpentry lessons will be meeting a few times
+before {month} for onboarding and training in the Carpentry maintenance
+workflow. Please fill out this schedule poll {add link to poll} by {deadline}
+with your general weekly availability. Our first meeting is tentatively set for
+the first week in {month} and we will be meeting three times. Don't forget to
+select your timezone before filling out your availability. We have new
+Maintainers joining the team from all over the world, so please be as flexible
+as possible.
+
+New Maintainers will be given write access to their lesson repos after
+completing the onboarding process. In the meantime, please start becoming
+familiar with your lesson materials, sign up for the [Maintainer mailing
+list](http://carpentries.topicbox.com/groups/maintainers), and check out the
+dates of the next [Maintainer general
+meeting](http://pad.software-carpentry.org/maintainers). You're more than
+welcome to start attending Maintainer meetings before our onboarding. Please let
+me know if you have any questions. Looking forward to seeing you in March!
+
+Best,
+{name}

--- a/email_templates/maintainers_onboarding_meetings.md
+++ b/email_templates/maintainers_onboarding_meetings.md
@@ -1,0 +1,35 @@
+Subject: Maintainer Onboarding Meetings
+
+Hi everyone,
+
+Thank you for adding your availability to the scheduling poll. Based on
+everyone's responses, we will be meeting at two different times. You do not need
+to attend the same meeting each week, and I would actually encourage those who
+can do so to switch which meeting they attend so that we can all meet one
+another over the course of the onboarding.
+
+We will be meeting for three weeks, starting the week of {date}. You can see the
+meeting times in your local time zone on
+[our Etherpad](http://pad.software-carpentry.org/maintainer-onboarding). 
+If you know that you will need to miss one of our meetings, please let me know
+as soon as possible so that we can make alternative arrangements for you to
+complete the training.
+
+Before our first meeting, please:
+
+1) Sign up for the [Maintainer mailing list](http://carpentries.topicbox.com/groups/maintainers).
+This is a low-volume channel for communicating about issues relevant to the
+Maintainer community.
+
+2) Add Maintainer meetings to your schedule. The meeting times are listed on the
+[Maintainer Etherpad](http://pad.software-carpentry.org/maintainers) and on the
+[Community Calendar](https://software-carpentry.org/join/#calendar). The
+Maintainer monthly meetings are not mandatory, but are encouraged as a way of
+getting to know the more experienced Maintainers.
+
+If you have any questions, please let me know.
+
+Looking forward to meeting all of you next month!
+
+Best,
+{name}

--- a/email_templates/missed_onboarding_meeting.md
+++ b/email_templates/missed_onboarding_meeting.md
@@ -1,0 +1,9 @@
+Subject: Unable to attend Maintainer Onboarding
+
+Thanks for letting me know. What I'm doing for people who have to miss a session
+is asking that they send me an email with their responses to the homeworks
+(including the preparatory homeworks) and discussions. Could you please take a
+look through the first lesson and send me your thoughts sometime next week?
+
+Best,
+{name}

--- a/email_templates/onboarding_reminder.md
+++ b/email_templates/onboarding_reminder.md
@@ -1,0 +1,23 @@
+Subject: Reminder - Onboarding starts next week
+
+Hi all,
+
+Just a quick reminder that we'll be starting our onboarding meetings next week.
+Please sign up for one of the two available sessions on our groups
+[Etherpad](http://pad.software-carpentry.org/maintainer-onboarding).
+
+During our meetings, we'll be test-running a
+[new curriculum for Maintainer Onboarding](https://carpentries.github.io/maintainer-onboarding/index.html).
+Your suggestions and pull requests to this repository are more than welcome!
+This curriculum will form the basis for onboarding of new groups of Maintainers
+in the future, so please help to improve it.
+
+Before our first meeting, please look at the first lesson in the Maintainer
+Onboarding curriculum
+([Social Aspects of Lesson Maintenance](https://carpentries.github.io/maintainer-onboarding/01-social/index.html))
+and do your best to work through the exercises marked "Preparatory Homework".
+
+Looking forward to seeing you all soon. Let me know if you have any questions.
+
+Best,
+{name}

--- a/email_templates/opportunities_to_complete_maintainer_onboarding.md
+++ b/email_templates/opportunities_to_complete_maintainer_onboarding.md
@@ -1,0 +1,24 @@
+Subject: Opportunities to complete Carpentry Maintainer onboarding
+
+Hi all,
+
+Thank you again for volunteering to act as a Carpentry Maintainer. You're
+getting this email because you expressed interested in being a Maintainer but
+were not able to attend the onboarding sessions. If you are still interested in
+becoming a Maintainer, please choose one of the two following paths:
+
+1) Reading through the three Maintainer Onboarding episodes, writing up your
+responses to the discussion questions and homeworks, and sending me your
+responses by {deadline}.
+
+or
+
+2) Joining the next Maintainer Onboarding session, which will be held in
+{month}.
+
+Please let me know as soon as possible which of these two paths you'd like to
+follow, or if you are no longer interested in joining the Maintainer team. main
+Looking forward to hearing back from you.
+
+Best,
+{name}

--- a/email_templates/welcoming_new_maintainers.md
+++ b/email_templates/welcoming_new_maintainers.md
@@ -1,0 +1,17 @@
+Subject: Welcome New Maintainers!
+
+Today I'm happy to announce the addition of {number} new Maintainers to our
+team. Please join me in welcoming:
+
+{Table of names and lessons for new Maintainers}
+
+Each of these new Maintainers has gone through a three week onboarding program
+to help prepare them for the complex role that Maintainers serve in our
+community. We certainly couldn't cover everything in these three meeting! Please
+help your new team mates as they run into snags and feel free to reach out to me
+with any questions or concerns.
+
+Looking forward to seeing everyone in action!
+
+Best,
+{name}

--- a/topic_folders/maintainers/email_templates.md
+++ b/topic_folders/maintainers/email_templates.md
@@ -1,112 +1,49 @@
 ### Email Templates
 
 
+
 #### Inviting new Maintainers
-Subject: Invitation to become a Carpentry Maintainer
-CC: Existing Maintainers for the repo and other new Maintainer applicants for the same repo.
-
-Hi all,
-
-Thank you for applying to become a Maintainer for {lesson name and link to repo}. We're excited to have you on the Maintainer team! Your co-Maintainers are cc'd here.
-
-As a Maintainer, you’re part of a team that is responsible for ensuring that your lesson materials stay up-to-date, accurate, functional and cohesive. You’ll monitor your lesson repository, make sure that PRs and Issues are addressed in a timely manner, and participate in the lesson development cycle including lesson releases. {Add a sentence about when the next lesson release is scheduled for.}
-
-The new Maintainers for all of the Carpentry lessons will be meeting a few times before {month} for onboarding and training in the Carpentry maintenance workflow. Please fill out this schedule poll {add link to poll} by {deadline} with your general weekly availability. Our first meeting is tentatively set for the first week in {month} and we will be meeting three times. Don't forget to select your timezone before filling out your availability. We have new Maintainers joining the team from all over the world, so please be as flexible as possible. 
-
-New Maintainers will be given write access to their lesson repos after completing the onboarding process. In the meantime, please start becoming familiar with your lesson materials, sign up for the [Maintainer mailing list](http://carpentries.topicbox.com/groups/maintainers), and check out the dates of the next [Maintainer general meeting](http://pad.software-carpentry.org/maintainers). You're more than welcome to start attending Maintainer meetings before our onboarding. Please let me know if you have any questions. Looking forward to seeing you in March!
-
-Best,
-{name}
 
 
+``` eval_rst
+.. literalinclude :: ../../email_templates/inviting_new_maintainers.md
+```
 
 
 #### Maintainer onboarding meetings
 
-Subject: Maintainer Onboarding Meetings
-
-Hi everyone,
-
-Thank you for adding your availability to the scheduling poll. Based on everyone's responses, we will be meeting at two different times. You do not need to attend the same meeting each week, and I would actually encourage those who can do so to switch which meeting they attend so that we can all meet one another over the course of the onboarding.
-
-We will be meeting for three weeks, starting the week of {date}. You can see the meeting times in your local time zone on [our Etherpad](http://pad.software-carpentry.org/maintainer-onboarding). If you know that you will need to miss one of our meetings, please let me know as soon as possible so that we can make alternative arrangements for you to complete the training.
-
-Before our first meeting, please:
-
-1) Sign up for the [Maintainer mailing list](http://carpentries.topicbox.com/groups/maintainers). This is a low-volume channel for communicating about issues relevant to the Maintainer community.
-
-2) Add Maintainer meetings to your schedule. The meeting times are listed on the [Maintainer Etherpad](http://pad.software-carpentry.org/maintainers) and on the [Community Calendar](https://software-carpentry.org/join/#calendar). The Maintainer monthly meetings are not mandatory, but are encouraged as a way of getting to know the more experienced Maintainers.
-
-If you have any questions, please let me know.
-
-Looking forward to meeting all of you next month!
-
-Best,
-{name}
-
+```eval_rst
+.. literalinclude :: ../../email_templates/maintainers_onboarding_meetings.md
+```	
 
 
 #### Onboarding reminder
 
-Subject: Reminder - Onboarding starts next week
-
-Hi all,
-
-Just a quick reminder that we'll be starting our onboarding meetings next week. Please sign up for one of the two available sessions on our groups [Etherpad](http://pad.software-carpentry.org/maintainer-onboarding). 
-
-During our meetings, we'll be test-running a [new curriculum for Maintainer Onboarding](https://carpentries.github.io/maintainer-onboarding/index.html). Your suggestions and pull requests to this repository are more than welcome! This curriculum will form the basis for onboarding of new groups of Maintainers in the future, so please help to improve it. 
-
-Before our first meeting, please look at the first lesson in the Maintainer Onboarding curriculum ([Social Aspects of Lesson Maintenance](https://carpentries.github.io/maintainer-onboarding/01-social/index.html)) and do your best to work through the exercises marked "Preparatory Homework".
-
-Looking forward to seeing you all soon. Let me know if you have any questions.
-
-Best,
-{name}
-
+```eval_rst
+.. literalinclude :: ../../email_templates/onboarding_reminder.md
+```
 
 
 #### Missed onboarding meeting
 
-Subject: Unable to attend Maintainer Onboarding
 
-Thanks for letting me know. What I'm doing for people who have to miss a session is asking that they send me an email with their responses to the homeworks (including the preparatory homeworks) and discussions. Could you please take a look through the first lesson and send me your thoughts sometime next week?
-
-Best,
-{name}
+```eval_rst
+.. literalinclude :: ../../email_templates/missed_onboarding_meeting.md
+```
 
 
 #### Welcoming new Maintainers
 
-Subject: Welcome New Maintainers!
 
-Today I'm happy to announce the addition of {number} new Maintainers to our team. Please join me in welcoming: 
+```eval_rst
+.. literalinclude :: ../../email_templates/welcoming_new_maintainers.md
+```
 
-{Table of names and lessons for new Maintainers}
 
-Each of these new Maintainers has gone through a three week onboarding program to help prepare them for the complex role that Maintainers serve in our community. We certainly couldn't cover everything in these three meeting! Please help your new team mates as they run into snags  and feel free to reach out to me with any questions or concerns. 
+#### Opportunities to complete Carpentry Maintainer onboarding
 
-Looking forward to seeing everyone in action!
 
-Best,
-{name}
+```eval_rst
+.. literalinclude :: ../../email_templates/opportunities_to_complete_maintainer_onboarding.md
+```
 
---------------------
-
-Subject: Opportunities to complete Carpentry Maintainer onboarding
-
-Hi all,
-
-Thank you again for volunteering to act as a Carpentry Maintainer. You're getting this email because you expressed interested in being a Maintainer but were not able to attend the onboarding sessions. If you are still interested in becoming a Maintainer, please choose one of the two following paths:
-
-1) Reading through the three Maintainer Onboarding episodes, writing up your responses to the discussion questions and homeworks, and sending me your responses by {deadline}.
-
-or
-
-2) Joining the next Maintainer Onboarding session, which will be held in {month}. 
-
-Please let me know as soon as possible which of these two paths you'd like to follow, or if you are no longer interested in joining the Maintainer team.
-
-Looking forward to hearing back from you.
-
-Best,
-{name}


### PR DESCRIPTION
Here is a solution to #229 that @maneesha brought up.

The emails are individually stored in a folder of this repository, and pages that need to include the text of the emails use the `.. literalinclude` functionality to display the content of the files.

People who use scripts to send these emails can modify their scripts to get the body of the emails directly from GitHub. 