### PR TITLE
capitalize titles of formal roles in The Carpentries

### DIFF
--- a/topic_folders/governance/bylaws.md
+++ b/topic_folders/governance/bylaws.md
@@ -31,7 +31,7 @@ Member Organisations have committed to supporting the maintenance and growth of 
 
 ## 4. Individual Voting Membership
 
-The Carpentries community includes many opportunities for involvement representing variable levels of commitment. All individuals participating in community activities are required to conform to the [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html). Individuals may choose to commit to serving in one or more formal roles in the community, such as instructor, trainer, or maintainer, as defined by [The Carpentries Handbook](https://docs.carpentries.org/index.html).
+The Carpentries community includes many opportunities for involvement representing variable levels of commitment. All individuals participating in community activities are required to conform to the [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html). Individuals may choose to commit to serving in one or more formal roles in the community, such as Instructor, Irainer, or Maintainer, as defined by [The Carpentries Handbook](https://docs.carpentries.org/index.html).
 
 ### Eligibility, Rights, and Termination for Voting Members
 Individuals who satisfy at least one of the following conditions are eligible for Voting Membership, as assessed in a yearly timeframe associated with the dates of the election (Dec 1 to Nov 30):


### PR DESCRIPTION
Capitalizing the formal roles within The Carpentries.

(Also submitting the PR to see if the CODEOWNERS set up is working)