### PR TITLE
Update Trainer Training commitment

### DIFF
--- a/topic_folders/instructor_training/trainers_training.md
+++ b/topic_folders/instructor_training/trainers_training.md
@@ -7,23 +7,19 @@ This outline represents the time commitment required for being an instructor Tra
 
 Instructor Trainers agree to abide by the [Code of Conduct](http://www.datacarpentry.org/code-of-conduct/) in all communications and interactions with The Carpentries community.
 
+* Trainees who are not previously certified Instructors will be asked to concurrently pursue [Instructor certification](https://carpentries.org/become-instructor/)
 * Read [How Learning Works](https://www.amazon.com/How-Learning-Works-Research-Based-Principles/dp/0470484101/) by Susan Ambrose and discuss in book club format with Trainers-in-training. Preliminary reading schedule.
-  * Time commitment: 1 hour per week for 8 weeks meetings; can miss one meeting; ~10 hours reading
+  * Time commitment: 1 hour per week for 10 weeks meetings; can miss one meeting; ~10 hours reading
 * Join Trainer meetings 
-  * Time commitment: 1 hour per month; can miss one meeting
-* Shadow a teaching demonstration session 
+  * Time commitment: 1 hour per month; review minutes for missed meetings
+* Shadow a teaching demonstration session (previously certified Instructors)
   * Time commitment: 1 hour one time
-* Shadow at least half a day of an online instructor training event 
+* Shadow at least half a day of an online instructor training event (previously certified Instructors) 
   * Time commitment: 4 hours one time
-* Teach once either online or in person with experienced Trainer (after finishing book club)
-  * Time commitment: 2 days one time plus prep
-* Agree to the [Trainer Agreement](duties_agreement.md). 
+* Agree to fulfill the duties outlined in the [Trainer Agreement](duties_agreement.md) for a period of 1 year. 
 
-Total time commitment for continuing Trainers: 
-4 days per year + 2.5 hrs per month
-
-Total time commitment for new Trainers: 
-3 days + ~30 hours over 3 month period, including reading and prep time 
+Total time commitment for previously certified Instructors to become certified Instructor Trainers: 
+~30 hours over 3 month period, including reading and prep time 
 
 #### Trainers Training Reading Schedule
 


### PR DESCRIPTION
Removes commitment and hours estimates specific to service as a Trainer, narrowing focus to Trainer Training only. Extends Trainer Training sessions to 10 vs 8.

