### PR TITLE
add guidelines for recruiting instructors

### DIFF
--- a/topic_folders/hosts_instructors/index.rst
+++ b/topic_folders/hosts_instructors/index.rst
@@ -1,5 +1,5 @@
 TEACHING AND HOSTING
-=======================
+##########################
 
 Opportunities for certified instructors to teach Carpentries workshops are listed `here <https://docs.google.com/spreadsheets/d/1YhTAzEalDqKUowgej7aRa7E1K0XcB6ZezoVUt6VN2qY/edit#gid=0>`_.  Join the `instructors mailing list <http://carpentries.topicbox.com/groups/instructors>`_ to be notified when new opportunities are posted.
 
@@ -9,16 +9,36 @@ have two options: a centrally-organised or self-organised workshop.
 One way to understand the distinction between centrally-organised and self-organised workshops is who 
 is responsible for certain key workshop components: 
 
-**Centrally Organized Workshop**
+Centrally Organized Workshop
+******************************
+
+    * registration managed by The Carpentries Workshop Administration Team
+    * instructor recruitment managed by The Carpentries Workshop Administration Team
+
+Self-Organized Workshop
+******************************
+
+    * registration managed by local organizer
+    * instructor recruitment managed by local organizer
 
 
-* registration managed by The Carpentries Workshop Administration Team
-* instructor recruitment managed by The Carpentries Workshop Administration Team
+.. note:: 
+    **Recruitment of Instructors for Self-Organised workshops**
 
-**Self-Organized Workshop**
+    If you are organising a Self-Organised workshop, there are resources for you to recruit Instructors, Supporting Instructors, and/or Helpers. Below are the channels you can use: 
 
-* registration managed by local organizer
-* instructor recruitment managed by local organizer
+    - Any local or group specific mailing list on `TopicBox <https://carpentries.topicbox.com/groups>`_
+
+    - Any local or group specific Slack channel
+
+    We ask that you only use the resources listed above. Please **do not** use the following channels. Any recruitment messages used on these channels will be removed.
+
+    * `Discuss list <https://carpentries.topicbox.com/groups/discuss>`_ on TopicBox
+
+    * `General Channel <https://swcarpentry.slack.com/archives/C03LE48AY>`_ on Slack
+
+    * `Instructors Channel <https://swcarpentry.slack.com/archives/C08BVNU00>`_ on Slack
+
 
 In both cases, the host site is expected to pay for instructor travel (if needed) and
 cover local costs.  For a centrally organised workshop, there is a fee if the organiser


### PR DESCRIPTION
Adds guidelines as recommended and drafted by @sheraaronhurt  on how Instructors, Supporting Instructors, and Helpers can be recruited for self organized workshops