### PR TITLE
Amending The Carpentries Bylaws 2020

### DIFF
--- a/topic_folders/governance/bylaws.md
+++ b/topic_folders/governance/bylaws.md
@@ -175,3 +175,4 @@ Any changes to these bylaws require a majority vote of the Executive Council. Th
 
 Update log:
 - [Approved 2018-11-01](https://github.com/carpentries/executive-council-info/issues/7) by the Executive Council
+- [Amended 2020-09-25](https://github.com/carpentries/docs.carpentries.org/pull/670) by the Executive Council

--- a/topic_folders/governance/bylaws.md
+++ b/topic_folders/governance/bylaws.md
@@ -1,16 +1,20 @@
 # The Carpentries Bylaws
 
+[The Executive Council welcomes community feedback on these bylaws. See [our contact information](https://static.carpentries.org/governance/#contacting-the-executive-council).]
+
 ## 1. Purpose
+
+**Vision**: The Carpentries vision is to be the leading inclusive community teaching data and coding skills.
 
 **Mission**: The Carpentries builds global capacity in essential data and computational skills for conducting efficient, open, and reproducible research. We train and foster an active, inclusive, diverse community of learners and instructors that promotes and models the importance of software and data in research. We collaboratively develop openly-available lessons and deliver these lessons using evidence-based teaching practices. We focus on people conducting and supporting research.
 
-## 2. Lesson Program Membership
+## 2. Lesson Programs
 
 ### Overview
-Lesson Programs are collections of lessons which comprise one or more Carpentries workshops and the leadership guiding their development and implementation. The following requirements outline the general expectations associated with Lesson Programs; additional detail can be found in the Lesson Program Policy.
+Lesson Programs are collections of lessons which comprise one or more Carpentries workshops and the leadership guiding their development and implementation. The following requirements outline the general expectations associated with Lesson Programs; additional detail can be found in the [Lesson Program Policy](https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html).
 
-### Eligibility for Lesson Program Membership
-The Executive Council is responsible for assessing a prospective Lesson Program for acceptance into The Carpentries, which requires a majority vote. The Executive Director will be responsible for developing and implementing policies related to Lesson Program incubation and assessing the ability of the Core Team and community to meet obligations associated with new Lesson Programs.
+### Eligibility for Lesson Program Acceptance
+The Executive Council is responsible for assessing a prospective Lesson Program for acceptance into The Carpentries, which requires a majority vote. The Executive Director in coordination with relevant core team and Executive Council members will be responsible for:  developing and implementing policies related to Lesson Program incubation and assessing the ability of the Core Team and community to meet obligations associated with new Lesson Programs.
 
 ### Roles and Responsibilities of Lesson Programs
 A Lesson Program within The Carpentries should possess the following characteristics:
@@ -31,19 +35,19 @@ Member Organisations have committed to supporting the maintenance and growth of 
 
 ## 4. Individual Voting Membership
 
-The Carpentries community includes many opportunities for involvement representing variable levels of commitment. All individuals participating in community activities are required to conform to the [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html). Individuals may choose to commit to serving in one or more formal roles in the community, such as instructor, trainer, or maintainer, as defined by [The Carpentries Handbook](https://docs.carpentries.org/index.html).
+The Carpentries community includes many opportunities for involvement representing variable levels of commitment. All individuals participating in community activities are required to conform to the [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html). Individuals may choose to commit to serving in one or more formal roles in the community, such as Instructor, Trainer, or Maintainer, as defined by [The Carpentries Handbook](https://docs.carpentries.org/index.html).
 
 ### Eligibility, Rights, and Termination for Voting Members
-Individuals who satisfy at least one of the following conditions are eligible for Voting Membership, as assessed in a yearly timeframe associated with the dates of the election (Dec 1 to Nov 30):
+In a yearly timeframe associated with the dates of the election, starting December 1st, individuals who satisfy at least one of the following conditions are eligible for Voting Membership:
 
-1. Every individual who has completed instructor or trainer certification in the past year
-2. Every individual who has completed their instructor certification in the last two years and has taught at least one workshop of The Carpentries
-3. Every individual who is a certified instructor and has taught at least two workshops of The Carpentries in the past two years
-4. Any individual who has participated on a committee, served as a mentor or maintainer, or otherwise made a significant contribution, to any Lesson Program or The Carpentries organisation in the past year, as determined on a case-by-case basis by the Executive Council, and thus is considered active in the community
+1. Every individual who has completed Instructor or Trainer certification in the past year
+2. Every individual who has completed their Instructor or Trainer certification in the last two years and has taught at least one official workshop of The Carpentries
+3. Every individual who is a certified Instructor or Trainer and has taught at least two official workshops of The Carpentries in the past two years
+4. Any individual who has participated on a committee, served as a Mentor or Maintainer, or otherwise made a significant contribution, to any Lesson Program or The Carpentries organisation in the past year, as determined on a case-by-case basis by the Executive Council, and thus is considered active in the community
 
 The Executive Director is not eligible for Voting Membership.
 
-All individuals who satisfy conditions for 1-3 above are automatically tracked and will receive Voting Membership. Any individual who only satisfies condition 4 may receive Voting Membership by contacting The Carpentries Core Team within a reasonable timeframe prior to release of ballots to confirm their participation, as dictated by the Election Policy. If you’re not sure if you’re a voting-eligible member, log in to [AMY](https://amy.carpentries.org/account/login/) and see if records show that you are eligible based on the criteria above. For more help with accessing and updating your AMY profile, please see [Accessing and Updating Your Instructor Profile](https://docs.carpentries.org/topic_folders/for_instructors/current_instructors.html#accessing-and-updating-your-instructor-profile)
+All individuals who satisfy conditions 1-3 above are automatically tracked and will receive Voting Membership. Any individual who only satisfies condition 4 may receive Voting Membership by contacting The Carpentries Core Team within a reasonable timeframe prior to release of ballots to confirm their participation, as dictated by the Election Policy. If you’re not sure if you’re a voting-eligible member, log in to [AMY](https://amy.carpentries.org/account/login/) and see if records show that you are eligible based on the criteria above. For more help with accessing and updating your AMY profile, please see [Accessing and Updating Your Instructor Profile](https://docs.carpentries.org/topic_folders/for_instructors/current_instructors.html#accessing-and-updating-your-instructor-profile)
 
 Any individual who no longer wishes to be affiliated with The Carpentries or included as a Voting Member must inform The Carpentries Core Team for removal from membership lists. Voting Membership may be terminated by a majority vote of the Executive Council for individuals who are recommended for termination by the Code of Conduct committee or Executive Director for non-compliance with The Carpentries policies or violation of the core values of The Carpentries.
 
@@ -51,7 +55,7 @@ Any individual who no longer wishes to be affiliated with The Carpentries or inc
 
 ### General Powers
 As the highest leadership body of the organisation, the Executive Council is responsible for:
-- determining the mission and purposes of the organisation
+- determining the mission, vision and purposes of the organisation
 - selecting the Executive Director and evaluating their performance
 - strategic and organisational planning
 - ensuring strong fiduciary oversight and financial management
@@ -62,7 +66,7 @@ As the highest leadership body of the organisation, the Executive Council is res
 
 ### Responsibilities of Executive Council Members
 Each Member of the Executive Council is responsible for:
-- knowing the organisation’s mission, policies, programs, and needs
+- knowing the organisation’s mission, vision, policies, programs, and needs
 - reading and understanding the organisation’s financial statements
 - serving as active advocates and ambassadors for the organisation necessary for The Carpentries to advance its mission
 - leveraging connections, networks, and resources to develop collective action to fully achieve The Carpentries’ mission
@@ -70,11 +74,11 @@ Each Member of the Executive Council is responsible for:
 - preparing for, attending, and conscientiously participating in Executive Council meetings
 
 ### Number, Tenure, Requirements, and Qualifications
-The Executive Council will be composed of nine (9) Members, each serving a two-year term, without limit on the number of terms. Member terms will begin on February 1st, except when filling between-election vacancies (see below). Five (5) Members of the Executive Council will be elected by the Executive Council (hereafter referred to as "Council-elected Members"). The other four (4) Members will be elected by the Membership of the organisation ("Community-elected Members").
+The Executive Council will be composed of nine Members, each serving a two-year term, without limit on the number of terms. Member terms will begin on February 1st following the election, except when filling between-election vacancies (see below). Five Members of the Executive Council will be elected by the Executive Council (hereafter referred to as "Council-elected Members"). The other four Members will be elected by the Membership of the organisation ("Community-elected Members").
 No employer may have more than two elected or appointed representatives on the Executive Council, and Carpentries Core Team are not eligible to serve as Executive Council Members. The Executive Council has the final say in determining whether people are working for the same employer. If more than two people who are working for the same employer are elected, they must step down one by one to be replaced by other nominees in order of the number of votes received.
 
 ### Regular Meetings and Quorum
-The Executive Council must meet at least ten (10) times per year, either in person or online. Quorum for meetings of the Executive Council is five Members, including at least one Council-elected and one Community-elected Member.
+The Executive Council must meet at least ten times per year, either in person or online. Quorum for meetings of the Executive Council is five Members, including at least one Council-elected and one Community-elected Member. The Executive Council may use an asynchronous public online voting mechanism for motions to be approved inbetween regular meetings.
 
 ### Compensation
 Members of the Executive Council shall not receive compensation from the Organisation for their service, with the exception of administrative support, travel, and accommodation costs related to their duties on the Executive Council.
@@ -83,25 +87,27 @@ Members of the Executive Council shall not receive compensation from the Organis
 Members of the Executive Council will sometimes discuss or be made aware of information or activities that may be sensitive to share publicly (e.g. salary information). Executive Council Members are expected to treat such information confidentially and to disclose such information to those outside the Executive Council only when the Executive Council has agreed that such dissemination is appropriate.
 
 ### Removal
-If a Member of the Executive Council consistently fails to meet the obligations outlined above, they may be removed by a vote of three-quarters (3/4) of the other Members of the Executive Council. A vote to remove a Member must be announced in writing to the entire Executive Council at least ten (10) days in advance of the vote. A vacated Executive Council seat will be filled following the Between-election vacancies procedure outlined in the Nominations and Elections section. 
+If a Member of the Executive Council consistently fails to meet the obligations outlined above, they may be removed by a vote of three-quarters of the other Members of the Executive Council. A vote to remove a Member must be announced in writing (in the meeting agenda) to the entire Executive Council at least ten days in advance to vote on the removal. A vacated Executive Council seat will be filled following the Between-election vacancies procedure outlined in the Nominations and Elections section. 
 
 ## 6. Nominations and Elections
 
 ### Overview
-Four (4) to five (5) of the nine (9) Members of the Executive Council will be elected each year, either by the community (Community-elected) or by the Executive Council (Council-elected). A general timeline for elections will occur annually as follows:
-- Mid-October: Executive Council announces election, soliciting self-nominations for Community-elected Members and recommendations for Council-elected Members, and identifying areas of expertise desired by the Council
-- Late November: Self-nominations and recommendations close and the Executive Council hosts Community Calls to discuss the election and introduce candidates for Community-elected Members
-- Early December: Voting Members vote for Community-elected Members
-- Mid-December: Executive Council elects Council-elected Members and announces the Executive Council Members for the following year
+Four to five of the nine Members of the Executive Council will be elected each year, either by the community (Community-elected) or by the Executive Council (Council-elected). A general timeline for elections will occur annually as follows:
+
+- Mid August: The Executive Council identifies an Executive Council member as point of contact for the election. The person should not be an Executive Council member who is standing for re-election
+- Early September: Executive Council announces election, soliciting self-nominations for Community-elected Members and recommendations for Council-elected Members, and identifying areas of expertise desired by the Council
+- Late October: Self-nominations and recommendations close and the Executive Council hosts Community Calls to discuss the election and introduce candidates for Community-elected Members
+- Early November: Voting Members vote for Community-elected Members
+- Mid-November: Executive Council elects Council-elected Members and announces the Executive Council Members for the following year
 - February 1: Responsibility for governance is transferred to the new Executive Council
 
 ### Community-elected Members
-Two (2) Community-elected Members will be elected each year by the Voting Members of The Carpentries. Any Voting Member of The Carpentries may stand for election by announcing their candidacy as dictated by the Election Policy; Carpentries Core Team may not stand for election. If there are fewer than two candidates for the election, the current Community-elected Members will decide amongst them who will remain in office.
+Two Community-elected Members will be elected each year by the Voting Members of The Carpentries. Any Voting Member of The Carpentries may stand for election by announcing their candidacy as dictated by the Election Policy; Carpentries Core Team may not stand for election. If there are fewer than two candidates for the election, the current Community-elected Members whose seats are up for election will decide amongst them who will remain in office.
 
 Elections will take place once every calendar year and no later than 30 days before the new Executive Council becomes active (February 1). Each Voting Member may vote for as many candidates as there are Community-elected Member seats to be filled. The candidates who receive the highest number of votes will be elected into the Executive Council.
 
 ### Council-elected Members
-Two (2) or three (3) of the Council-elected Members will be elected each year. The Executive Council must consider at least one more candidate than the number of Council-elected Member seats to be filled. Anyone may recommend candidates for Council-elected positions.
+Two or three of the Council-elected Members will be elected each year. The Executive Council must consider at least one more candidate than the number of Council-elected Member seats to be filled. Anyone may recommend candidates for Council-elected positions.
 
 Executive Council selects, by anonymous vote, the Council-elected Members from among the recommended candidates. Appointed Members will abstain from voting when they themselves are recommended for reappointment. Each Executive Council Member may vote for as many individuals as there are Council-elected Member seats to be filled. The individuals with the highest number of votes will be appointed. This vote will not take place until after the voting results for Community-elected Members are known and no later than December 15th.
 
@@ -121,7 +127,8 @@ Responsibilities of each officer of the Executive Council are as follows:
 - Work in partnership with the Executive Director to make sure that resolutions are carried out and issues addressed by the Executive Council as needed
 - Prepare the agenda for Executive Council meetings
 - Oversee the search for a new Executive Director (when applicable)
-- Coordinate the Executive Director's annual performance evaluation  		
+- Coordinate the Executive Director's annual performance evaluation
+- The board chair shall serve for renewable one-year terms. They shall serve not more than five consecutive years.
 
 ### Vice-Chair
 - Understand the responsibilities of the Executive Council Chair and be able to perform these duties in the chair's absence
@@ -129,12 +136,12 @@ Responsibilities of each officer of the Executive Council are as follows:
 - Ensure the circulation of agendas, minutes, and other communications to the Executive Council
 - Ensure that any Executive Council members who have been given tasks know what it is they have been asked to do
 - Check that action has been taken following decisions at previous meetings
+- Receive all communication from community to Executive Council and relay as necessary
 
 ### Secretary
 - Ensure that someone is assigned to and takes minutes during all official EC meetings
 - Revise minutes for publication
 - Report decisions, policy, and action items in formal minutes published publicly (when applicable)
-- Receive all communication from community to Executive Council and relay as necessary
 
 ### Treasurer
 - Assist the Executive Director in preparing financial reports for both the Executive Council and community at large
@@ -142,7 +149,7 @@ Responsibilities of each officer of the Executive Council are as follows:
 - Answer Executive Council Members’ questions about the budget and finances
 
 ### Election of Officers
-All officers must be members of the Executive Council. Officers will be selected via majority voting of the Executive Council at the first regular meeting of the year.
+All officers must be members of the Executive Council. Officers will be selected via majority voting of the Executive Council at the first regular meeting of the Executive Council’s term.
 
 ### Removal of Officers
 If an officer steps down, is removed from the Executive Council, or is otherwise unable to meet their obligations as determined by the Chair and/or Vice Chair, a new officer will be elected from the remaining Executive Council Members.
@@ -155,9 +162,9 @@ Committees are organised by the Executive Council to carry out specific tasks as
 ## 9. Core Team
 
 ### Executive Director
-The Executive Director acts as the Chief Executive Officer of The Carpentries in accordance with its vision and mission as overseen by the Executive Council. The Executive Director provides oversight and overall management, planning, vision and leadership for all aspects of The Carpentries including programs, finances, resource development, human resources, member services, communications, and Executive Council development. The Executive Director assumes a leadership role in partnering with collaborating organisations, businesses, universities, foundations, government agencies, other nonprofits and supporters. The Executive Director works with the Executive Council to establish vision, policies, strategic focus, priorities, and general scope of programs The Carpentries will deliver, and communicates on progress towards these goals via an annual report.
+The Executive Director acts as the Chief Executive Officer of The Carpentries in accordance with its vision and mission as overseen by the Executive Council. The Executive Director provides oversight and overall management, planning, vision and leadership for all aspects of The Carpentries including programs, finances, resource development, human resources, member services, communications, and Executive Council development. The Executive Director assumes a leadership role in partnering with collaborating organisations, businesses, universities, foundations, government agencies, other nonprofits and supporters. The Executive Director works with the Executive Council to establish vision, policies, strategic focus, priorities, and general scope of programs. The Carpentries will deliver, and communicates on progress towards these goals via an annual report.
 
-The Executive Council is responsible for advertising and interviewing for the position of Executive Director. A majority vote of the Executive Council is required to hire or remove the Executive Director from their position.
+The Executive Council is responsible for advertising, conducting interviews and setting the salary level for the position of Executive Director. A majority vote of the Executive Council is required to hire or remove the Executive Director from their position.
 
 ## 10. Amendments
 


### PR DESCRIPTION
This Pull request add all the amendments the Executive Council has approved up to date as part of the Bylaw Revision process. 

Note that approval of this PR needs a **majority vote of the Executive Council**, only then can it be merged.

Amendments are:

- adds vision
- clarify language around Lesson Programs and Lesson Program membership
- adds link to the Lesson Program Policy
- individual Voting Membership
  - clarify that for eligibility, 'the past year' is associated with the dates of the election
  - puts certification as Trainer on equal footing with certification as Instructor for eligibility criteria
- Executive Council
  - add determining the vision as a responsibility of the Executive Council
  - clarify when Executive Council member terms begin
  - add use of asynchronous public online voting for motions
  - clarify procedure for removal of a Executive Council member
  - Elections
    - adjust timeline, most steps move a month earlier in the year
   - clarity that Trainer certification 
    - clarify procedure for when there are not enough nominations for council-elected seats
  - set term limit for Executive Council Chair
  - Move the responsibility for receiving communication from community to Executive Council from Secretary to Vice Chair
  - clarify when the new Executive Council elects its officers
- clarify the role for the Executive Council in the hiring of the Executive Director

Minor changes:
- capitalization of Instructor, Trainer, Maintainer
- spelling and grammar improvements