### PR TITLE
Fix section links in Privacy Policy

### DIFF
--- a/topic_folders/policies/privacy.md
+++ b/topic_folders/policies/privacy.md
@@ -5,12 +5,12 @@
 This Privacy Policy covers personally identifiable information that may be provided to The Carpentries, including data provided at in-person events (e.g., workshops and conferences) and online. Changes to this Privacy Policy will be posted on this page. Any changes will only apply to information collected after the posted date of any such change. Additionally, information may be provided to governmental bodies and other entities as required by law.
 Information obtained and how it is used is described in sections below for
 
-1. [Workshop participants](#section-i-workshop-participants)  
-2. [Instructors](#section-ii-instructors)  
-3. [Other volunteers](#section-iii-other-volunteers)  
-4. [Online spaces](#section-iv-online-spaces)  
-5. [Opt-in surveys](#section-v-opt-in-surveys)  
-6. [All participants](#section-vi-all-participants)
+1. [Workshop participants](#section-1-workshop-participants)  
+2. [Instructors](#section-2-instructors)  
+3. [Other volunteers](#section-3-other-volunteers)  
+4. [Online spaces](#section-4-online-spaces)  
+5. [Opt-in surveys](#section-5-opt-in-surveys)  
+6. [All participants](#section-6-all-participants)
 
 
 ## Definitions
@@ -33,48 +33,48 @@ Personally identifiable information is stored in secure databases. Refer to [Lim
 Access will be limited to The Carpentries Core Team and authorised administrators.
 
 ## Section 1: Workshop Participants
-Workshop participants include Learners, Helpers and Hosts
+Workshop participants include Learners, Helpers and Hosts.
 
 #### What information do we obtain?
-We may obtain the name, email address and event attended of workshop participants. If you are a learner or helper, this information may be provided by you or by the workshop host. See [Section V: Opt-in Surveys](#section-v-opt-in-surveys) for information on our Opt-In surveys.
+We may obtain the name, email address and event attended of workshop participants. If you are a learner or helper, this information may be provided by you or by the workshop host. See [Section 5: Opt-in Surveys](#section-5-opt-in-surveys) for information on our Opt-In surveys.
 
 #### How is this information used?
 We use this information to communicate with participants, including sending workshop information and program evaluation forms. Names and email addresses may be shared with the workshop host for the purpose of workshop logistics. Additionally, we may use your information to contact you about additional opt-in opportunities for training, teaching, surveys and/or community engagement. This information may also be used for statistical purposes. We do not provide personally identifiable information to any third party. However, we may share de-identified aggregate or summary information regarding participants publicly or with volunteers, partners or third parties, including but not limited to funding entities.
-See [Section VI: All Participants](#section-vi-all-participants) for further information
+See [Section 6: All Participants](#section-6-all-participants) for further information.
 
 ## Section 2: Instructors
 
-Instructors includes Instructors, Trainers, Instructor Trainees and Instructor Applicants
+Instructors includes Instructors, Trainers, Instructor Trainees and Instructor Applicants.
 
 #### What information do we obtain?
 We may obtain the name and email address of participants at instructor training events and of current instructors. This information may be provided by the participant or event host. If you choose to complete a volunteer/instructor profile, we may store your name, email address, gender, nearest airport location, organisational affiliation, occupation, ORCID ID, GitHub and Twitter handle, and personal URL.
 
 #### How is this information used?
 We use this information to communicate with Instructors, including for instructor training events, training completion materials, communication about the organisation, and opportunities to volunteer. Additionally, we may use volunteer information to contact you about additional opt-in opportunities for assessment, training, teaching, volunteering and/or community engagement. This information may also be used for statistical purposes. We do not provide personally identifiable information to any third party. However, we may share de-identified aggregate or summary information regarding instructors publicly or with volunteers, partners or third parties, including but not limited to funding entities.
-See [Section VI: All Participants](#section-vi-all-participants) for further information
+See [Section 6: All Participants](#section-6-all-participants) for further information.
 
 ## Section 3: Other Volunteers
 
-Other Volunteers includes Lesson contributors and maintainers and Volunteers for subcommittees or programs
+Other Volunteers includes Lesson contributors and maintainers and Volunteers for subcommittees or programs.
 
 #### What information do we obtain?
 We may obtain the name and email address of Other volunteers. If you choose to complete a volunteer/instructor profile, we may store your name, email address, gender, nearest airport location, organisational affiliation, occupation, ORCID ID, GitHub and Twitter handle, and personal URL.
 
 #### How is this information used?
 We use this information to communicate with Other volunteers, including communication about the organisation and opportunities to volunteer. Additionally, we may use volunteer information to contact you about additional opt-in opportunities for assessment, training, teaching, volunteering and/or community engagement. This information may also be used for statistical purposes. We do not provide personally identifiable information to any third party. However, we may share de-identified aggregate or summary information regarding volunteers publicly or with other volunteers, partners or third parties, including but not limited to funding entities.
-See [Section VI: All Participants](#section-vi-all-participants) for further information
+See [Section 6: All Participants](#section-6-all-participants) for further information.
 
 ## Section 4: Online Spaces
-This Privacy Policy is applicable to information that you provided/collected through physical (such as a paper form) and online means, including through our websites or other external online spaces (including but not limited to GitHub repositories, Etherpads, Google Documents, EventBrite and mailing lists). By using these spaces, you agree to the terms of this Privacy Policy. Some of these tools and services (including but not limited to GitHub, Google Documents, Eventbrite and SurveyMonkey) have their own independent privacy policies. See [Section V: Opt-In Surveys](#section-v-opt-in-surveys), for information specifically on survey information.
+This Privacy Policy is applicable to information that you provided/collected through physical (such as a paper form) and online means, including through our websites or other external online spaces (including but not limited to GitHub repositories, Etherpads, Google Documents, EventBrite and mailing lists). By using these spaces, you agree to the terms of this Privacy Policy. Some of these tools and services (including but not limited to GitHub, Google Documents, Eventbrite and SurveyMonkey) have their own independent privacy policies. See [Section 5: Opt-In Surveys](#section-5-opt-in-surveys), for information specifically on survey information.
 
 #### What information do we obtain?
 We may collect information about visitors’ devices and browsers, such as browser version and type, IP address, website referred from and country of visitor.
 In addition, we may collect textual input (e.g. Etherpad entries) from you which may be associated with your name, affiliation and/or social media handles.
-If you provide financial information to pay for a workshop or partnership or make a donation, the transaction information will be processed on a third-party secured site. This information will only be accessible to our Core Team or authorised administrators and to the Core Team of our fiscal sponsor who is involved in processing financial transactions. We engage with third-parties (including but not limited to Square, WeDidIt, Eventbrite) to gather and collect this information securely and do not have access to or store any payment details in our systems
+If you provide financial information to pay for a workshop or partnership or make a donation, the transaction information will be processed on a third-party secured site. This information will only be accessible to our Core Team or authorised administrators and to the Core Team of our fiscal sponsor who is involved in processing financial transactions. We engage with third-parties (including but not limited to Square, WeDidIt, Eventbrite) to gather and collect this information securely and do not have access to or store any payment details in our systems.
 
 #### What do we do with this information?
 We use this information to improve our sites and services. In addition, we may use contact information that you provide to contact you about additional opt-in opportunities for assessment, training, teaching, and/or community engagement. This information may also be used for statistical purposes. We do not provide personally identifiable information to any third party. However, we may share de-identified aggregate or summary information regarding visitors publicly or with volunteers, partners or third parties, including but not limited to funding entities. We may use publicly available data of the external online services in programmatic analysis and evaluation.
-See [Section VI: All Participants](#section-vi-all-participants) for further information
+See [Section 6: All Participants](#section-6-all-participants) for further information.
 
 ## Section 5: Opt-in Surveys
 Community and workshop participants are invited to participate in a variety of opt-in surveys to better serve our community. These include but are not limited to pre-workshop and post-workshop surveys of learners and various survey instruments to evaluate programs or events. 
@@ -85,7 +85,7 @@ Surveys collect information particular to the event or program being evaluated a
 
 #### What do we do with this information?
 We use this information to help evaluate and improve programs, report on impact and outcomes and understand the needs and interests of our community. This information may be used for statistical purposes. We do not provide personally identifiable information to any third party. However, we may share de-identified aggregate or summary information publicly or with volunteers, partners or third parties, including but not limited to funding entities. Where we share open-ended responses or testimonials, we always do so anonymously or ask for explicit consent to allow de-identified responses.
-See [Section VI: All Participants](#section-vi-all-participants) for further information
+See [Section 6: All Participants](#section-6-all-participants) for further information.
 
 ## Section 6: All Participants
 


### PR DESCRIPTION
I noticed the section links in the Privacy Policy don't work. This PR should fix that, and add some missing period characters at the end of some sentences.