### PR TITLE
Add documentation for and by the Executive Council

### DIFF
--- a/topic_folders/governance/executive-council-officers.md
+++ b/topic_folders/governance/executive-council-officers.md
@@ -58,14 +58,13 @@ The Vice Chair’s responsibilities are to:
 
 More specifically, the Vice Chair should:
 
-
 * Monitor activities of the EC:
   * Ensure all obligations of members of the Executive Council are being fulfilled, particularly those of the Chair
   * Track all items in the yearly [EC timeline](https://docs.carpentries.org/topic_folders/governance/executive-council.html#yearly-timeline
 )
   * Check that the meeting minutes are approved (via GitHub vote in a private repo) and published (in the public EC repo) within two weeks of the meeting occurring
   * Watch issues/PRs in all GitHub repositories and taking appropriate action as necessary: adding to agendas, noting in nonverbal updates for meetings, etc.
-* Elections: so far the Vice Chair has been point of contact for the elections. The complete process is documented [here](https://docs.google.com/document/d/1qg__La6vsBfw2vEO22ftalIOdnUsvZ1CGldz1Em3zPM/edit)<sup>*</sup>. At the very least, the Vice Chair should ensure each part of the election process is delegated to someone.
+* Elections: so far the Vice Chair has been point of contact for the elections. The complete process is documented in a <u>Google Doc</u><sup>*</sup> (Elections --> EC Election Process.gdoc). At the very least, the Vice Chair should ensure each part of the election process is delegated to someone.
 * Communications
   * Send newsletter updates to the appropriate Carpentries core team member to be published. The newsletter is published every other Wednesday, and updates should be sent the prior Friday. These updates are important to help the community know what the Executive Council does and to encourage feedback and communication about our activities
   * Monitor communication from the community. As described [elsewhere](https://docs.carpentries.org/topic_folders/governance/executive-council.html#communication), community members may use a Google Form, an email address or GitHub issues to communicate with the EC
@@ -81,7 +80,7 @@ The Secretary’s responsibilities are to:
 * Revise minutes of regularly occurring meetings to report decisions, policy, and passage of formal motions prior to
 circulation among the Executive Council for approval.
 * Publish meeting minutes and policy decisions
-  * publicly for the community, as described in the "Meeting conduct" document under the section ["Preparing the minutes for release"](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit#heading=h.yg8xqbjr7yxb)<sup>*</sup>
+  * publicly for the community, as described in the <u>Meeting conduct document</u><sup>*</sup> (Agendas_Minutes --> Meeting conduct.gdoc) under the section "Preparing the minutes for release"
   * or, if necessary, in secure locations only accessible to the Executive Council or Executive Council/Executive Director.
 
 ### Treasurer
@@ -96,10 +95,10 @@ The Treasurer’s responsibilities are to:
 * Ensure that an up-to-date report on the status of accounts can be given at each Council meeting.
 * Maintain open lines of communication with the Executive Director and the fiscal sponsor.
 
-Practical information for the Treasurer role can be found in a [private document](https://docs.google.com/document/d/1i7BX7PEU9kF3fNLh7aD3qD0Ro3bKwdIzqL9UoglGZTc/edit?usp=sharing).
+Practical information for the Treasurer role can be found in a <u>Google Doc</u><sup>*</sup> (Finance --> Treasurer: practical information.gdoc).
 
 
-<sup>*</sup>Access to this link is restricted to Executive Council members.
+<sup>*</sup>Access to this information is restricted to Executive Council members.
 
 <!--
 Original sources:

--- a/topic_folders/governance/executive-council-officers.md
+++ b/topic_folders/governance/executive-council-officers.md
@@ -61,13 +61,14 @@ More specifically, the Vice Chair should:
 
 * Monitoring activities of the EC:
   * Ensure all obligations of members of the Executive Council are being fulfilled, particularly those of the Chair
-  * Track all items in the yearly [EC timeline]() FIXME link to executive-council#yearly-timeline
+  * Track all items in the yearly [EC timeline](https://docs.carpentries.org/topic_folders/governance/executive-council.html#yearly-timeline
+)
   * Check that the meeting minutes are approved (via GitHub vote in a private repo) and published (in the public EC repo) within two weeks of the meeting occurring
   * Watch issues/PRs in all GitHub repositories and taking appropriate action as necessary: adding to agendas, noting in nonverbal updates for meetings, etc.
-* Elections: so far the Vice Chair has been point of contact for the elections. The complete process is documented [here](https://docs.google.com/document/d/1qg__La6vsBfw2vEO22ftalIOdnUsvZ1CGldz1Em3zPM/edit). At the very least, the Vice Chair should ensure each part of the election process is delegated to someone.
+* Elections: so far the Vice Chair has been point of contact for the elections. The complete process is documented [here](https://docs.google.com/document/d/1qg__La6vsBfw2vEO22ftalIOdnUsvZ1CGldz1Em3zPM/edit)<sup>*</sup>. At the very least, the Vice Chair should ensure each part of the election process is delegated to someone.
 * Communications
   * Send newsletter updates to the appropriate Carpentries team member. The newsletter is published every other Wednesday, and updates should be sent the prior Friday. These updates are important to help the community know what the Executive Council does and to encourage feedback and communication about our activities
-  * Monitor communication from the community. As described in the FIXME link to executive-council#communication, community members may use a Google Form, an email address or GitHub issues to communicate with the EC
+  * Monitor communication from the community. As described [elsewhere](https://docs.carpentries.org/topic_folders/governance/executive-council.html#communication), community members may use a Google Form, an email address or GitHub issues to communicate with the EC
 
 ### Secretary
 
@@ -80,7 +81,7 @@ The Secretary’s responsibilities are to:
 * Revise minutes of regularly occurring meetings to report decisions, policy, and passage of formal motions prior to
 circulation among the Executive Council for approval.
 * Publish meeting minutes and policy decisions
-  * publicly for the community, as described in the "Meeting conduct" document under the section ["Preparing the minutes for release"](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit#heading=h.yg8xqbjr7yxb)
+  * publicly for the community, as described in the "Meeting conduct" document under the section ["Preparing the minutes for release"](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit#heading=h.yg8xqbjr7yxb)<sup>*</sup>
   * or, if necessary, in secure locations only accessible to the Executive Council or Executive Council/Executive Director.
 
 ### Treasurer
@@ -97,8 +98,13 @@ The Treasurer’s responsibilities are to:
 
 Practical information for the Treasurer role can be found in a [Google Doc](https://docs.google.com/document/d/1i7BX7PEU9kF3fNLh7aD3qD0Ro3bKwdIzqL9UoglGZTc/edit?usp=sharing).
 
+
+<sup>*</sup>Access to this link is restricted to Executive Council members.
+
+<!--
 Original sources:
 
 - [Chair](https://docs.google.com/document/d/1bW2TqnFrT-pSlASZvtRkJ89WsbeCGDoETpEXUkHGLyI/edit)
 - [Vice Chair](https://docs.google.com/document/d/1mjsv0bVc6TlVSuMS0Fp3KTtSWglEULvP4u_ngpP73rU/edit)
 - [Treasurer](https://docs.google.com/document/d/1i7BX7PEU9kF3fNLh7aD3qD0Ro3bKwdIzqL9UoglGZTc/edit#heading=h.r2lkwgs29qo0)
+-->

--- a/topic_folders/governance/executive-council-officers.md
+++ b/topic_folders/governance/executive-council-officers.md
@@ -12,25 +12,25 @@ This document describes their tasks in more detail.
 
 ### Chair
 
-The Chair’s primary role is to organize and facilitate the activities of the Council. General tasks are described in
+The Chair’s primary role is to organise and facilitate the activities of the Council. General tasks are described in
 [the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council).
 
 The Chair’s responsibilities are to:
 
-* Organize official meetings, including regularly occurring monthly meetings and additional special meetings as necessary.
+* Organise official meetings, including regularly occurring monthly meetings and additional special meetings as necessary.
   * Set meeting times and make sure these are properly adjusted with respect to daylight savings (which does not change for all members at the same time)
   * Send out reminder email 7-10 days before each monthly meeting (more details in the monthly minutes document)
   * Plan dates, location, and agenda for the annual in-person meeting with input from the rest of the EC
 * Set the agenda and ensure that it is circulated in a timely fashion to allow EC members to prepare for the meeting.
   * Review submissions to the agenda form and add these to the agenda for the meeting
-  * Invite non-members to the EC meeting as needed for specific discussions, such as staff, CI representatives
+  * Invite non-members to the EC meeting as needed for specific discussions, such as staff, Community Initiatives (CI) representatives
 * Ensure meetings are led fairly and transparently.
   * Make sure the Secretary is posting minutes for approval, voted on by EC members, and published in the public repository all in a timely fashion.
   * Make sure that motions are voted on in a timely fashion (send out a notice when they are ready for voting and reminders as necessary to the group or individuals).
 * Facilitate the formation of necessary Committees and appointments of EC liaisons.
   * Make sure that committees and task forces report back to the EC on their work at monthly meetings, either verbally or in non-verbal updates.
 * Act as the primary liaison between the Executive Director and the Executive Council.
-  * This typically involves a monthly meeting with the ED to discuss current issues and possible agenda items for the next monthly meeting and is typically two weeks offset from the monthly EC meeting.
+  * This typically involves a monthly meeting with the Executive Director (ED) to discuss current issues and possible agenda items for the next monthly meeting and is typically two weeks offset from the monthly Executive Council (EC) meeting.
 * Coordinate the Executive Director’s annual performance evaluation (November)
 * Oversee the search for a new Executive Director when necessary.
 * Ensure that EC members are aware of their duties and responsibilities.
@@ -59,7 +59,7 @@ The Vice Chair’s responsibilities are to:
 More specifically, the Vice Chair should:
 
 
-* Monitoring activities of the EC:
+* Monitor activities of the EC:
   * Ensure all obligations of members of the Executive Council are being fulfilled, particularly those of the Chair
   * Track all items in the yearly [EC timeline](https://docs.carpentries.org/topic_folders/governance/executive-council.html#yearly-timeline
 )
@@ -67,7 +67,7 @@ More specifically, the Vice Chair should:
   * Watch issues/PRs in all GitHub repositories and taking appropriate action as necessary: adding to agendas, noting in nonverbal updates for meetings, etc.
 * Elections: so far the Vice Chair has been point of contact for the elections. The complete process is documented [here](https://docs.google.com/document/d/1qg__La6vsBfw2vEO22ftalIOdnUsvZ1CGldz1Em3zPM/edit)<sup>*</sup>. At the very least, the Vice Chair should ensure each part of the election process is delegated to someone.
 * Communications
-  * Send newsletter updates to the appropriate Carpentries team member. The newsletter is published every other Wednesday, and updates should be sent the prior Friday. These updates are important to help the community know what the Executive Council does and to encourage feedback and communication about our activities
+  * Send newsletter updates to the appropriate Carpentries core team member to be published. The newsletter is published every other Wednesday, and updates should be sent the prior Friday. These updates are important to help the community know what the Executive Council does and to encourage feedback and communication about our activities
   * Monitor communication from the community. As described [elsewhere](https://docs.carpentries.org/topic_folders/governance/executive-council.html#communication), community members may use a Google Form, an email address or GitHub issues to communicate with the EC
 
 ### Secretary
@@ -96,7 +96,7 @@ The Treasurer’s responsibilities are to:
 * Ensure that an up-to-date report on the status of accounts can be given at each Council meeting.
 * Maintain open lines of communication with the Executive Director and the fiscal sponsor.
 
-Practical information for the Treasurer role can be found in a [Google Doc](https://docs.google.com/document/d/1i7BX7PEU9kF3fNLh7aD3qD0Ro3bKwdIzqL9UoglGZTc/edit?usp=sharing).
+Practical information for the Treasurer role can be found in a [private document](https://docs.google.com/document/d/1i7BX7PEU9kF3fNLh7aD3qD0Ro3bKwdIzqL9UoglGZTc/edit?usp=sharing).
 
 
 <sup>*</sup>Access to this link is restricted to Executive Council members.

--- a/topic_folders/governance/executive-council-officers.md
+++ b/topic_folders/governance/executive-council-officers.md
@@ -1,0 +1,104 @@
+## The Carpentries Executive Council Officer Positions
+
+General tasks for each officer position are described in
+[the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council).
+this document derscribes their tasks in more detail.
+
+
+* [Chair](#chair)
+* [Vice Chair](#vice_chair)
+* [Secretary](#secretary)
+* [Treasurer](#treasurer)
+
+### Chair
+
+The Chair’s primary role is to organize and facilitate the activities of the Council. General tasks are described in
+[the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council).
+
+The Chair’s responsibilities are to:
+
+* Organize official meetings, including regularly occurring monthly meetings and additional special meetings as necessary.
+  * Set meeting times and make sure these are properly adjusted with respect to daylight savings (which does not change for all members at the same time)
+  * Send out reminder email 7-10 days before each monthly meeting (more details in the monthly minutes document)
+  * Plan dates, location, and agenda for the annual in-person meeting with input from the rest of the EC
+* Set the agenda and ensure that it is circulated in a timely fashion to allow EC members to prepare for the meeting.
+  * Review submissions to the agenda form and add these to the agenda for the meeting
+  * Invite non-members to the EC meeting as needed for specific discussions, such as staff, CI representatives
+* Ensure meetings are led fairly and transparently.
+  * Make sure the Secretary is posting minutes for approval, voted on by EC members, and published in the public repository all in a timely fashion.
+  * Make sure that motions are voted on in a timely fashion (send out a notice when they are ready for voting and reminders as necessary to the group or individuals).
+* Facilitate the formation of necessary Committees and appointments of EC liaisons.
+  * Make sure that committees and task forces report back to the EC on their work at monthly meetings, either verbally or in non-verbal updates.
+* Act as the primary liaison between the Executive Director and the Executive Council.
+  * This typically involves a monthly meeting with the ED to discuss current issues and possible agenda items for the next monthly meeting and is typically two weeks offset from the monthly EC meeting.
+* Coordinate the Executive Director’s annual performance evaluation (November)
+* Oversee the search for a new Executive Director when necessary.
+* Ensure that EC members are aware of their duties and responsibilities.
+* The EC member who holds the position of Chair has ideally served on the EC for at least one year prior to accepting the office and is willing to remain accessible to the Chair who accepts the position following their departure from office.
+
+* The following additional tasks also fall to the Chair:
+  * Make sure Code of Conduct Transparency Reports are completed in a timely fashion and published in the public repository.
+  * Close GitHub issues in the EC repositories as needed
+  * Onboard new members (with the Vice Chair)
+  * Generally track goals of the EC to ensure that the EC is focusing on the right tasks and that tasks are completed in a timely fashion.
+
+### Vice Chair
+
+The Vice-Chair’s primary roles are to perform the tasks of the Chair in the event of their absence and to ensure communication
+of Executive Council activities to the Carpentries community. General tasks are described in
+[the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#vice-chair).
+
+The Vice Chair’s responsibilities are to:
+
+* Understand the responsibilities of the Executive Council Chair and be able to perform these duties in the chair’s absence
+* Ensure the circulation of agendas, minutes, and other communications to the Executive Council
+* Ensure that any Executive Council members who have been given tasks know what it is they have been asked to do
+* Check that action has been taken following decisions at previous meetings
+* Serve as the primary liaison for communication between the community and the Executive Council. Primary tasks include reporting from EC meetings for the newsletter, as well as monitoring GitHub issues and private email.
+
+More specifically, the Vice Chair should:
+
+
+* Monitoring activities of the EC:
+  * Ensure all obligations of members of the Executive Council are being fulfilled, particularly those of the Chair
+  * Track all items in the yearly [EC timeline]() FIXME link to executive-council#yearly-timeline
+  * Check that the meeting minutes are approved (via GitHub vote in a private repo) and published (in the public EC repo) within two weeks of the meeting occurring
+  * Watch issues/PRs in all GitHub repositories and taking appropriate action as necessary: adding to agendas, noting in nonverbal updates for meetings, etc.
+* Elections: so far the Vice Chair has been point of contact for the elections. The complete process is documented [here](https://docs.google.com/document/d/1qg__La6vsBfw2vEO22ftalIOdnUsvZ1CGldz1Em3zPM/edit). At the very least, the Vice Chair should ensure each part of the election process is delegated to someone.
+* Communications
+  * Send newsletter updates to the appropriate Carpentries team member. The newsletter is published every other Wednesday, and updates should be sent the prior Friday. These updates are important to help the community know what the Executive Council does and to encourage feedback and communication about our activities
+  * Monitor communication from the community. As described in the FIXME link to executive-council#communication, community members may use a Google Form, an email address or GitHub issues to communicate with the EC
+
+### Secretary
+
+The Secretary maintains records for the Executive Council that are not related to either finances or the Core Team. General tasks are described in
+[the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#secretary).
+
+The Secretary’s responsibilities are to:
+
+* Ensure that someone is assigned to and takes minutes during all official Executive Council meetings
+* Revise minutes of regularly occurring meetings to report decisions, policy, and passage of formal motions prior to
+circulation among the Executive Council for approval.
+* Publish meeting minutes and policy decisions
+  * publicly for the community, as described in the "Meeting conduct" document under the section ["Preparing the minutes for release"](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit#heading=h.yg8xqbjr7yxb)
+  * or, if necessary, in secure locations only accessible to the Executive Council or Executive Council/Executive Director.
+
+### Treasurer
+
+The Treasurer organizes and maintains financial records for Executive Council oversight of The Carpentries operations. General tasks are
+described in [the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#treasurer).
+
+The Treasurer’s responsibilities are to:
+
+* Assist the Executive Director in preparing financial reports for both the Executive Council and the community at large
+* Assist the Executive Director in preparing the annual budget and presenting the budget to the Executive Council for approval
+* Ensure that an up-to-date report on the status of accounts can be given at each Council meeting.
+* Maintain open lines of communication with the Executive Director and the fiscal sponsor.
+
+Practical information for the Treasurer role can be found in a [Google Doc](https://docs.google.com/document/d/1i7BX7PEU9kF3fNLh7aD3qD0Ro3bKwdIzqL9UoglGZTc/edit?usp=sharing).
+
+Original sources:
+
+- [Chair](https://docs.google.com/document/d/1bW2TqnFrT-pSlASZvtRkJ89WsbeCGDoETpEXUkHGLyI/edit)
+- [Vice Chair](https://docs.google.com/document/d/1mjsv0bVc6TlVSuMS0Fp3KTtSWglEULvP4u_ngpP73rU/edit)
+- [Treasurer](https://docs.google.com/document/d/1i7BX7PEU9kF3fNLh7aD3qD0Ro3bKwdIzqL9UoglGZTc/edit#heading=h.r2lkwgs29qo0)

--- a/topic_folders/governance/executive-council-officers.md
+++ b/topic_folders/governance/executive-council-officers.md
@@ -64,7 +64,7 @@ More specifically, the Vice Chair should:
 )
   * Check that the meeting minutes are approved (via GitHub vote in a private repo) and published (in the public EC repo) within two weeks of the meeting occurring
   * Watch issues/PRs in all GitHub repositories and taking appropriate action as necessary: adding to agendas, noting in nonverbal updates for meetings, etc.
-* Elections: so far the Vice Chair has been point of contact for the elections. The complete process is documented in a <u>Google Doc</u><sup>*</sup> (Elections --> EC Election Process.gdoc). At the very least, the Vice Chair should ensure each part of the election process is delegated to someone.
+* Elections: so far the Vice Chair has been point of contact for the elections. The complete process is documented in a <u>Google Doc</u><sup>*</sup> (Folder Elections --> EC Election Process.gdoc). At the very least, the Vice Chair should ensure each part of the election process is delegated to someone.
 * Communications
   * Send newsletter updates to the appropriate Carpentries core team member to be published. The newsletter is published every other Wednesday, and updates should be sent the prior Friday. These updates are important to help the community know what the Executive Council does and to encourage feedback and communication about our activities
   * Monitor communication from the community. As described [elsewhere](https://docs.carpentries.org/topic_folders/governance/executive-council.html#communication), community members may use a Google Form, an email address or GitHub issues to communicate with the EC
@@ -80,7 +80,7 @@ The Secretary’s responsibilities are to:
 * Revise minutes of regularly occurring meetings to report decisions, policy, and passage of formal motions prior to
 circulation among the Executive Council for approval.
 * Publish meeting minutes and policy decisions
-  * publicly for the community, as described in the <u>Meeting conduct document</u><sup>*</sup> (Agendas_Minutes --> Meeting conduct.gdoc) under the section "Preparing the minutes for release"
+  * publicly for the community, as described in the <u>Meeting conduct</u> document<sup>*</sup> (folder Agendas_Minutes --> Meeting conduct.gdoc) under the section "Preparing the minutes for release"
   * or, if necessary, in secure locations only accessible to the Executive Council or Executive Council/Executive Director.
 
 ### Treasurer
@@ -95,7 +95,7 @@ The Treasurer’s responsibilities are to:
 * Ensure that an up-to-date report on the status of accounts can be given at each Council meeting.
 * Maintain open lines of communication with the Executive Director and the fiscal sponsor.
 
-Practical information for the Treasurer role can be found in a <u>Google Doc</u><sup>*</sup> (Finance --> Treasurer: practical information.gdoc).
+Practical information for the Treasurer role can be found in a <u>Google Doc</u><sup>*</sup> (folder Finance --> Treasurer: practical information.gdoc).
 
 
 <sup>*</sup>Access to this information is restricted to Executive Council members.

--- a/topic_folders/governance/executive-council-officers.md
+++ b/topic_folders/governance/executive-council-officers.md
@@ -2,7 +2,7 @@
 
 General tasks for each officer position are described in
 [the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council).
-this document derscribes their tasks in more detail.
+This document describes their tasks in more detail.
 
 
 * [Chair](#chair)

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -2,7 +2,7 @@
 
 ### About the Executive Council
 
-The Carpentries Executive Council is the highest leadership body of The Carpentries. It is responsible for strategic and organizational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image. Members of the Council also serve as advocates and ambassadors for the organization, leveraging their networks to benefit the organization’s reputation and fundraising. The Executive Council executes these responsibilities through a combination of monthly Executive Council meetings and regular correspondence and collaboration via email and online platforms.
+The Carpentries Executive Council is the highest leadership body of The Carpentries. It is responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image. Members of the Council also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the organization’s reputation and fundraising. The Executive Council executes these responsibilities through a combination of monthly Executive Council meetings and regular correspondence and collaboration via email and online platforms.
 
 The governance of The Carpentries by the Executive Council is outlined in the [Bylaws](bylaws.md).
 
@@ -37,7 +37,7 @@ but sometimes we need to choose to withhold information from others.
 
 The [Carpentries Bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council)
 describe the formal responsibilities of the Executive Council from an
-organizational level. This text describes the current implementation of the tasks described in the bylaws and represents
+organisational level. This text describes the current implementation of the tasks described in the bylaws and represents
 flexible guidelines that may be adapted as the Executive Council deems necessary. In addition to documenting Executive Council standard operating
 procedures, it is also intended to clarify Executive Council function for the broader community and help potential members understand the
 commitment to serve on the Executive Council.
@@ -70,7 +70,7 @@ terms. Officer positions include:
 * Secretary
 * Treasurer
 
-General tasks for each offiver position are described in
+General tasks for each officer position are described in
 [the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council).
 More detailed descriptions can be found on the page describing the [Executive Council officers responsibilities](executive-council-officers.html).
 
@@ -143,7 +143,7 @@ This is a GitHub organisation 'owned' by the Executive Council, used for informa
 <https://github.com/carpentries-ec/financeviz><sup>*</sup>
 
 * *private* repository, Executive Council, Executive Director and the Core Team have access
-* used for visualizations and plots for communicating The Carpentries finances
+* used for visualisations and plots for communicating The Carpentries finances
 
 ### Google Drive
 
@@ -180,7 +180,7 @@ Additional recurring tasks:
 * Reassess meeting procedures, including methods for setting the agenda and taking minutes
 * Review previous year’s financial report for new Executive Council
 * Select new officers
-* Finalize annual goals for Executive Council
+* Finalise annual goals for Executive Council
 
 #### March
 * Annual financial report for community
@@ -224,7 +224,7 @@ Additional recurring tasks:
 * First full week (Monday-Friday) in December: elections open
 * Selection of appointed members
 * Announcement of the new Executive Council
-* Start organizing dates for face-to-face meeting in first half of year
+* Start organising dates for face-to-face meeting in first half of year
 * Review and discussion of strategic plan activities
 
 
@@ -271,8 +271,8 @@ The outgoing Chair and/or Vice Chair should meet with the incoming Executive Cou
 Executive Council members have access to the following resources:
 
 * Google Drive
-* GitHub organizations, teams, and repositories
-  * Organization: carpentries
+* GitHub organisations, teams, and repositories
+  * Organisation: carpentries
     * Team: carpentries/executive-council
     * Repo: executive-council-info (public, this repository)
   * Repo: private (Executive Council + the Core Team)

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -86,7 +86,7 @@ We use two mailing lists:
 The Executive Council generally meets once monthly (we are required to hold at least 10 meetings a year, either in person or online). Smaller groups of Executive Council members may hold additional meetings when needed.
 
 - [Publicly available meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes)
-- [Meeting conduct](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit?usp=sharing)<sup>*</sup>: how we prepare for and conduct regular meetings
+- [Meeting conduct](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit?usp=sharing): how we prepare for and conduct regular meetings
 - [Agendas and minutes directory](https://drive.google.com/drive/folders/1iaDOmMPxkHtkHH-wAHK_LPNmNSNjynrN)<sup>*</sup>: we use a single document for meeting agendas/minutes for the entire year (meetings from February - January)
 - Scheduling through [Google calendar](https://calendar.google.com/calendar/ical/q7j1ftdldoaapso2on44qrdnps%40group.calendar.google.com/private-426a931882cc901bd08f0f49ee2d0bb4/basic.ics)<sup>*</sup>
 - Executive Council members are invited to attend the Core Team meetings whenever they desire

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -86,14 +86,24 @@ We use two mailing lists:
 The Executive Council generally meets once monthly (we are required to hold at least 10 meetings a year, either in person or online). Smaller groups of Executive Council members may hold additional meetings when needed.
 
 - [Publicly available meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes)
-- [Meeting conduct](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit?usp=sharing): how we prepare for and conduct regular meetings
-- [Agendas and minutes directory](https://drive.google.com/drive/folders/1iaDOmMPxkHtkHH-wAHK_LPNmNSNjynrN)<sup>*</sup>: we use a single document for meeting agendas/minutes for the entire year (meetings from February - January)
-- Scheduling through [Google calendar](https://calendar.google.com/calendar/ical/q7j1ftdldoaapso2on44qrdnps%40group.calendar.google.com/private-426a931882cc901bd08f0f49ee2d0bb4/basic.ics)<sup>*</sup>
+- See the <u>Agendas and minutes directory</u><sup>*</sup> in our Google Drive. We use a single document for meeting agendas/minutes for the entire year (meetings from February - January)
+- Our <u>Meeting conduct</u><sup>*</sup> describes how we prepare for and conduct regular meetings, see the Google Doc in the above-mentioned folder (Agendas_Minutes --> Meeting conduct.gdoc)
+- Scheduling is done through our Google calendar
 - Executive Council members are invited to attend the Core Team meetings whenever they desire
 
-### Finances
+### Finances and Fiscal Sponsor
 
-See the [Finance folder](https://drive.google.com/drive/folders/1521cY9O-ud5UahP9IM0BoxFAvZDspx9t)<sup>*</sup> in Google Drive
+See the <u>Finance folder</u><sup>*</sup> in our Google Drive.
+
+#### The Carpentries Fiscal Sponsor
+
+The Carpentries is fiscally sponsored by [Community Initiatives](https://communityin.org/), a registered 501c3 based in Oakland, CA. Here are some relevant resources:
+
+*   [What is fiscal sponsorship?](https://communityin.org/fiscal-sponsorship/solving-problems-for-nonprofits/#fiscal-sponsorship)
+*   Who are CI's [other fiscally sponsored projects](https://communityin.org/our-projects/support-a-project/) (FSPs)?
+
+See also the Community Initiative's bylaws and the Carpentries’ fiscal sponsor agreement in the <u>Fiscal Sponsor</u><sup>*</sup> folder on Google Drive (EC_processes --> Fiscal_Sponsor).
+
 
 ### GitHub
 
@@ -147,7 +157,7 @@ This is a GitHub organisation 'owned' by the Executive Council, used for informa
 
 ### Google Drive
 
-We use a private [Google Drive folder](https://drive.google.com/drive/folders/1Ss6oh2vfLc_pE8xk9UpOh9UUwSpDBr2g)<sup>*</sup>. See its [README](https://docs.google.com/document/d/1wYSRcD2504Xxpl9TlSerexIh6z5kBkq2CVbP2eofl4o/edit_) for orientation to contents.
+We use a private Google Drive folder<sup>*</sup>, see its README for orientation to contents.
 
 ### Yearly Timeline
 
@@ -232,12 +242,10 @@ Additional recurring tasks:
 
 Details about how Executive Council Members are elected and their terms of service are available in the [bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#nominations-and-elections). Elections are currently administered by an Executive Council Member (who is not up for re-election) via [ElectionBuddy](https://electionbuddy.com).
 
-A checklist for the Executive Council election process is available as a
-[Google Doc](https://docs.google.com/document/d/1qg__La6vsBfw2vEO22ftalIOdnUsvZ1CGldz1Em3zPM/edit?usp=sharing)<sup>*</sup>.
+A checklist for the Executive Council election process is available as a <u>Google Doc<u><sup>*</sup> in our Google Drive (Elections --> EC Election Process.gdoc)
 
 An overview of whose council member's seats are up for (re-)election
-can be found in a [Google Sheet](https://docs.google.com/spreadsheets/d/1OJQr9HMdfQ0AEwBviajTlrQuhIIE2Zu4b_g-b77aB2s/edit?usp=sharing)<sup>*</sup>.
-
+can be found in a <u>Google Sheet</u><sup>*</sup> (Elections --> Year-of-term for executive council members.gsheet).
 
 ### Transitions between Executive Councils
 
@@ -249,7 +257,7 @@ The transfer of responsibilities to the incoming Executive Council includes
 * [updating access to resources](#access-to-resources)
 * [selecting members to serve in specific roles](#transfer-of-member-responsibilities)
 
-A checklist for the transition process can be found as a [Google Doc](https://docs.google.com/document/d/1rMoTIOWiMMExe_WzHrRv3Ye8Yra5WyTas5zAOdAbRDA/edit?usp=sharing)<sup>*</sup>.
+A checklist for the transition process can be found as a <u>Google Doc</u><sup>*</sup> (EC_processes --> Onboarding_offboarding members, ED.gdoc).
 
 
 #### Onboarding new Executive Council members
@@ -301,8 +309,7 @@ The following Executive Council roles should be assigned at the February meeting
   * CoC representative
   * Representatives to Community Initiatives (CI)
 
-<sup>*</sup>Access to this link is restricted to Executive Council members.
-
+<sup>*</sup>Access to this information is restricted to Executive Council members.
 
 <!--
 Original sources:

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -86,14 +86,14 @@ We use two mailing lists:
 The Executive Council generally meets once monthly (we are required to hold at least 10 meetings a year, either in person or online). Smaller groups of Executive Council members may hold additional meetings when needed.
 
 - [Publicly available meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes)
-- See the <u>Agendas and minutes directory</u><sup>*</sup> in our Google Drive. We use a single document for meeting agendas/minutes for the entire year (meetings from February - January)
-- Our <u>Meeting conduct</u><sup>*</sup> describes how we prepare for and conduct regular meetings, see the Google Doc in the above-mentioned folder (Agendas_Minutes --> Meeting conduct.gdoc)
-- Scheduling is done through our Google calendar
+- See the <u>Agendas and minutes</u> folder<sup>*</sup> in the Executive Council Google Drive. We use a single document for meeting agendas/minutes for the entire year (meetings from February - January)
+- Our <u>Meeting conduct</u> document<sup>*</sup> describes how we prepare for and conduct regular meetings, see the Google Doc in the above-mentioned folder (folder Agendas_Minutes --> Meeting conduct.gdoc)
+- Scheduling is done through our Google calendar<sup>*</sup>
 - Executive Council members are invited to attend the Core Team meetings whenever they desire
 
 ### Finances and Fiscal Sponsor
 
-See the <u>Finance folder</u><sup>*</sup> in our Google Drive.
+See the <u>Finance</u> folder<sup>*</sup> in the Executive Council Google Drive.
 
 #### The Carpentries Fiscal Sponsor
 
@@ -102,7 +102,7 @@ The Carpentries is fiscally sponsored by [Community Initiatives](https://communi
 *   [What is fiscal sponsorship?](https://communityin.org/fiscal-sponsorship/solving-problems-for-nonprofits/#fiscal-sponsorship)
 *   Who are CI's [other fiscally sponsored projects](https://communityin.org/our-projects/support-a-project/) (FSPs)?
 
-See also the Community Initiative's bylaws and the Carpentries’ fiscal sponsor agreement in the <u>Fiscal Sponsor</u><sup>*</sup> folder on Google Drive (EC_processes --> Fiscal_Sponsor).
+See also the Community Initiative's bylaws and the Carpentries’ fiscal sponsor agreement in the <u>Fiscal Sponsor</u> folder<sup>*</sup> on the Executive Council Google Drive (folder EC_processes --> folder Fiscal_Sponsor).
 
 
 ### GitHub
@@ -157,7 +157,7 @@ This is a GitHub organisation 'owned' by the Executive Council, used for informa
 
 ### Google Drive
 
-We use a private Google Drive folder<sup>*</sup>, see its README for orientation to contents.
+We use a private Google Drive folder called <u>Carpentries_Executive_Council</u><sup>*</sup>, see its README for orientation to contents.
 
 ### Yearly Timeline
 
@@ -242,10 +242,10 @@ Additional recurring tasks:
 
 Details about how Executive Council Members are elected and their terms of service are available in the [bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#nominations-and-elections). Elections are currently administered by an Executive Council Member (who is not up for re-election) via [ElectionBuddy](https://electionbuddy.com).
 
-A checklist for the Executive Council election process is available as a <u>Google Doc<u><sup>*</sup> in our Google Drive (Elections --> EC Election Process.gdoc)
+A checklist for the Executive Council election process is available as a <u>Google Doc</u><sup>*</sup> in the Executive Council Google Drive (folder Election --> EC Election Process.gdoc)
 
 An overview of whose council member's seats are up for (re-)election
-can be found in a <u>Google Sheet</u><sup>*</sup> (Elections --> Year-of-term for executive council members.gsheet).
+can be found in a <u>Google Sheet</u><sup>*</sup> (folder Elections --> Year-of-term for executive council members.gsheet).
 
 ### Transitions between Executive Councils
 
@@ -257,7 +257,7 @@ The transfer of responsibilities to the incoming Executive Council includes
 * [updating access to resources](#access-to-resources)
 * [selecting members to serve in specific roles](#transfer-of-member-responsibilities)
 
-A checklist for the transition process can be found as a <u>Google Doc</u><sup>*</sup> (EC_processes --> Onboarding_offboarding members, ED.gdoc).
+A checklist for the transition process can be found as a <u>Google Doc</u><sup>*</sup> (folder EC_processes --> Onboarding_offboarding members, ED.gdoc).
 
 
 #### Onboarding new Executive Council members
@@ -278,7 +278,7 @@ The outgoing Chair and/or Vice Chair should meet with the incoming Executive Cou
 
 Executive Council members have access to the following resources:
 
-* Google Drive
+* Google Drive folder <u>Carpentries_Executive_Council</u>
 * GitHub organisations, teams, and repositories
   * Organisation: carpentries
     * Team: carpentries/executive-council

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -1,13 +1,314 @@
 ## The Carpentries Executive Council
 
-### Activities
+### About the Executive Council
 
-The highest leadership body of The Carpentries is the [Executive Council](https://carpentries.org/governance/), which is generally responsible for strategic and organizational planning. The governance of The Carpentries by the Executive Council is outlined in the [Bylaws](bylaws.md). Additional information about the Executive Council, including meeting minutes, Code of Conduct Transparency Reports, and details about operations, can be found [here](https://github.com/carpentries/executive-council-info), as well as their [Roles and Responsibilities](https://github.com/carpentries/executive-council-info/blob/master/process/roles_responsibilities.md#).
+The Carpentries Executive Council is the highest leadership body of The Carpentries. It is responsible for strategic and organizational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image. Members of the Council also serve as advocates and ambassadors for the organization, leveraging their networks to benefit the organization’s reputation and fundraising. The Executive Council executes these responsibilities through a combination of monthly Executive Council meetings and regular correspondence and collaboration via email and online platforms.
 
-In addition to publicly posting meeting minutes, the Executive Council reports on its activities periodically in [Carpentry Clippings](https://carpentries.org/newsletter/) (the organizational newsletter) as well as [blog posts](https://carpentries.org/posts-by-tags/#blog-tag-governance). 
+The governance of The Carpentries by the Executive Council is outlined in the [Bylaws](bylaws.md).
 
-If you have a question or concern for the Executive Council, please see instructions [here](https://github.com/carpentries/executive-council-info) for communicating with Executive Council Members.
+In addition to [publicly posting meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes), the Executive Council reports on its activities periodically in [Carpentry Clippings](https://carpentries.org/newsletter/) (the organizational newsletter) as well as [blog posts](https://carpentries.org/posts-by-tags/#blog-tag-governance).
+The council also prepares [Yearly Summaries](https://github.com/carpentries/executive-council-info/tree/master/year-in-review) of its activities.
+
+
+### Contacting the Executive Council
+If you have a question or concern for the Executive Council,
+there are three ways for communicating with Executive Council Members:
+
+1. **File an [issue](https://github.com/carpentries/executive-council-info/issues) in this repository.** This is appropriate if you would like to solicit additional community feedback on a topic of general interest to the community.
+2. **Send us an [email](mailto:carpentries-executive-council@carpentries.org).** This is appropriate for communicating directly with the Executive Council but not the rest of our community.
+3. **Submit [this form](https://docs.google.com/forms/d/e/1FAIpQLScdo7AlYfeQN-z5dnO-p8KVI8t17kQUc1VH-Cvrlga5txIwCA/viewform?usp=sf_link).** This is preferable if you would like confidential communication with the Executive Council, or if you would like to remain anonymous.
+
 
 ### Elections
 
-Details about how Executive Council Members are elected and their terms of service are available in the [bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#nominations-and-elections). Elections are currently administered by an Executive Council Member (who is not up for re-election) via [ElectionBuddy](https://electionbuddy.com). 
+Details about how Executive Council Members are elected and their terms of service are available in the [bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#nominations-and-elections). Elections are currently administered by an Executive Council Member (who is not up for re-election) via [ElectionBuddy](https://electionbuddy.com).
+
+A checklist for the Executive Council election process is available as a
+[Google Doc](https://docs.google.com/document/d/1qg__La6vsBfw2vEO22ftalIOdnUsvZ1CGldz1Em3zPM/edit?usp=sharing).
+An overview of whose council member's seats are up for (re-)election
+can be found in a [Google Sheet](https://docs.google.com/spreadsheets/d/1OJQr9HMdfQ0AEwBviajTlrQuhIIE2Zu4b_g-b77aB2s/edit?usp=sharing).
+
+### The Carpentries Executive Council Documentation
+
+The information below describes all procedures, routines and resources
+relevant for the Executive Council.
+This information is added here as onboarding information
+for new Executive Council members,
+as well as to provide transparency for the community.
+
+NOTE that a number of links lead to pages for which access is
+restricted to Executive Council members.
+We wish to be as transparent as we can,
+but sometimes we need to choose to withhold information from others.
+
+[from https://github.com/carpentries/executive-council-info/blob/master/process/roles_responsibilities.md]
+
+#### Responsibilities of all Executive Council Members
+
+The [Carpentries Bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council)
+describe the formal responsibilities of the Executive Council from an
+organizational level. This text describes the current implementation of the tasks described in the bylaws and represents
+flexible guidelines that may be adapted as the Executive Council deems necessary. In addition to documenting Executive Council standard operating
+procedures, it is also intended to clarify Executive Council function for the broader community and help potential members understand the
+commitment to serve on the Executive Council.
+
+In practice, each Executive Council member is responsible for the following general tasks:
+
+* Supporting the Mission and Vision of The Carpentries
+* Exemplifying the Code of Conduct
+* Ensuring The Carpentries’ adherence to legal agreements and standards
+* Offering their expertise to help ensure the health and success of the organization
+* Actively participating in discussions about strategic and financial decisions
+* Providing feedback and voting on formal motions within one week of their posting
+* Attending (in person or by phone/web-based) at least 75% of the meetings held each year
+* Dedicating at least three volunteer hours per week toward Carpentries activities (including meeting attendance)
+
+The specific commitments expected of Executive Council members include monthly meetings (1-1.5 hours, online) and a once-yearly
+face-to-face meeting (expenses covered by The Carpentries). Minutes for these meetings are published to [a GitHub repository](https://github.com/carpentries/executive-council-info/tree/master/minutes) after
+approval by Executive Council members. We may periodically schedule additional virtual meetings to address particular topics. Officers and Executive Council
+liaisons to Committees or Task Forces may have additional commitments for meetings. Asynchronous commitments involve suggesting
+agenda items for meetings, responding to email requests for opinions, and formal voting on resolutions (as issues in this
+repository), and work resulting from being on a task force or committee representing the Executive Council.
+
+### Officers
+
+Executive Council officers are selected at the first regular meeting following election and appointment of new members and serve one year
+terms. Officer positions include:
+
+* Chair
+* Vice Chair
+* Secretary
+* Treasurer
+
+General tasks for each offiver position are described in
+[the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council).
+More detailed descriptions can be found on the page describing the [Executive Council officers responsibilities](executive-council-officers.html).
+
+### Communication
+
+We use two mailing lists:
+
+* executive-council@carpentries.org: this is an internal list, and includes Executive Council and Executive Director; this list can only receive messages from list members
+* carpentries-executive-council@carpentries.org: recipients are Executive Council Chair and Vice Chair; anyone can send to this, allowing the community to communicate directly with the Executive Council (but not the rest of our community)
+
+### Meetings
+
+The Executive Council generally meets once monthly (we are required to hold at least 10 meetings a year, either in person or online). Smaller groups of Executive Council members may hold additional meetings when needed.
+
+- [Publicly available meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes)
+- [Meeting conduct](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit?usp=sharing): how we prepare for and conduct regular meetings
+- [Agendas and minutes directory](https://drive.google.com/drive/folders/1iaDOmMPxkHtkHH-wAHK_LPNmNSNjynrN): we use a single document for meeting agendas/minutes for the entire year (meetings from February - January)
+- Scheduling through [Google calendar](https://calendar.google.com/calendar/ical/q7j1ftdldoaapso2on44qrdnps%40group.calendar.google.com/private-426a931882cc901bd08f0f49ee2d0bb4/basic.ics)
+- Executive Council members are invited to attend the Core Team meetings whenever they desire
+
+### Finances
+
+See the [Finance folder](https://drive.google.com/drive/folders/1521cY9O-ud5UahP9IM0BoxFAvZDspx9t) in Google Drive
+
+### GitHub
+
+We maintain multiple repositories with variable permissions (some public, some restricted to Executive Council and/or various Core Team members).
+
+#### Under https://github.com/carpentries
+
+This is a GitHub organisation 'owned' by The Carpentries Core Team. Executive council members have access, as well as members of the Core Team and some community members
+
+https://github.com/carpentries/executive-council-info
+
+* *public* repository
+* used to publish information intended for the community, such as our monthly meeting minutes
+
+https://github.com/carpentries-ec/conversations_ec_ed
+
+* *private* repository. Executive council members have access, as well as the Executive Director
+* used for
+    * off-meeting discussions and voting, through the issue functionality
+    * storing relevant information that needs to be private to the world, and necessary or OK for the Executive Director or the Core Team to have access to
+
+https://github.com/carpentries/executive-council
+
+* *private* repository
+* used for discussions between Executive Council and Executive Director that require broader direct feedback from the Core Team
+* issues for approval of meeting minutes are posted here
+
+#### Under https://github.com/carpentries-ec
+
+This is a GitHub organisation 'owned' by the Executive Council, used for information or documents that *only* Executive Council members should have access to. Optionally, the Executive Director can be given access by inviting them as collaborator.
+
+https://github.com/carpentries-ec/conversations_ec_ed
+
+* *private* repository, only Executive Council and Executive Director have access (not the Core Team)
+* used to discuss issues between Executive Council and Executive Director outside of the Executive Council monthly meetings
+
+https://github.com/carpentries-ec/minutes-private
+
+* *private* repository, *only Executive Council* (not Executive Director or the Core Team) have access
+* used for
+  * those parts of the minutes that only Executive Council should have access to
+  * voting on motions that should only be visible to Executive Council.
+    Examples of such discussions and motions:
+    * hiring of a new Executive Director
+    * salary discussions/decisions
+
+https://github.com/carpentries-ec/financeviz
+
+* *private* repository, Executive Council, Executive Director and the Core Team have access
+* used for visualizations and plots for communicating The Carpentries finances
+
+### Google Drive
+
+We use a private Google Drive folder called ['Executive Council'](https://drive.google.com/drive/folders/1Ss6oh2vfLc_pE8xk9UpOh9UUwSpDBr2g). See its [README](https://docs.google.com/document/d/1wYSRcD2504Xxpl9TlSerexIh6z5kBkq2CVbP2eofl4o/edit_) for orientation to contents.
+
+### Yearly Timeline
+
+[From https://github.com/carpentries/executive-council-info/blob/master/process/timeline.md]
+
+Additional annual tasks:
+
+* in-person (face-to-face) meeting
+* reassessing the strategic plan
+* annual finance audit
+
+Additional recurring tasks:
+
+* every second year, starting 2020: revision or reapproval of the bylaws
+
+#### January
+* Review previous year’s minutes, ensuring all are approved and posted
+* Onboarding meeting for incoming Executive Council members with current Chair and/or Vice Chair and Executive Director
+* Overlap meeting of outgoing/incoming members
+* Logistics of offboarding outgoing members
+* Logistics of onboarding new members
+* Solicit nominations for Executive Council officers
+* Suggest annual goals for new Executive Council
+* Assess availability of incoming Executive Council Members for in-person meeting
+* Review Q4 financial report
+* Publish Q4 Code of Conduct Transparency Report
+
+#### February
+* New Executive Council officially takes over
+* Reassess meeting procedures, including methods for setting the agenda and taking minutes
+* Review previous year’s financial report for new Executive Council
+* Select new officers
+* Finalize annual goals for Executive Council
+
+#### March
+* Annual financial report for community
+* Review and discussion of strategic plan activities
+
+#### April
+* Review Q1 financial report
+* Publish Q1 Code of Conduct Transparency Report
+
+#### May
+
+#### June
+* Review and discussion of strategic plan activities
+
+#### July
+* Review Q2 financial report
+* Publish Q2 Code of Conduct Transparency Report
+
+#### August
+
+#### September
+* Assign individuals to reassess bylaws (required in even-numbered years, due in November)
+* Review and discussion of strategic plan activities
+
+#### October
+* Assess desired skills for incoming Executive Council members
+* Announce opening of self-nomination for Executive Council
+* Solicit nominees for community awards
+* Review Q3 financial report
+* Publish Q3 Code of Conduct Transparency Report
+
+#### November
+* Executive Director evaluation
+* Solicit nominations for appointed members
+* Nominations for Executive Council elections close (at start of first community call)
+* Community call for Executive Council nominees
+* Vote on reassessed bylaws
+
+#### December
+* Announce community award winners
+* First full week (Monday-Friday) in December: elections open
+* Selection of appointed members
+* Announcement of the new Executive Council
+* Start organizing dates for face-to-face meeting in first half of year
+* Review and discussion of strategic plan activities
+
+
+### Transitions between Executive Councils
+
+[From https://github.com/carpentries/executive-council-info/blob/master/process/EC_transition.md]
+
+The transfer of responsibilities to the incoming Executive Council includes
+
+* [onboarding new members to Executive Council processes](#onboarding-new-executive-council-members)
+* [updating access to resources](#access-to-resources)
+* [selecting members to serve in specific roles](#transfer-of-member-responsibilities)
+
+A checklist for the transition process can be found as a [Google Doc](https://docs.google.com/document/d/1rMoTIOWiMMExe_WzHrRv3Ye8Yra5WyTas5zAOdAbRDA/edit?usp=sharing).
+
+
+#### Onboarding new Executive Council members
+
+New (incoming) members (both Community-elected and Council-elected) are announced in late December/early January. The official term of office for incoming Executive Council members is February 1. We ask that incoming members attend the final regularly scheduled meeting of the current Executive Council in January,
+prior to taking office, to learn how meetings operate, and to prepare for formal transfer of responsibility.
+
+The outgoing Chair and/or Vice Chair should meet with the incoming Executive Council members and Executive Director in January to discuss the following key points:
+
+* The general workflow of the Executive Council
+  * monthly meetings
+  * as-needed special meetings and yearly in-person meeting
+  * asynchronous communications
+* Where different types of information are stored
+* Responsibilities and expectations for all Executive Council members
+
+#### Access to resources
+
+Executive Council members have access to the following resources:
+
+* Google Drive
+* GitHub organizations, teams, and repositories
+  * Organization: carpentries
+    * Team: carpentries/executive-council
+    * Repo: executive-council-info (public, this repository)
+  * Repo: private (Executive Council + the Core Team)
+    * Team: carpentries-ec/ec
+    * Repo: Executive Council + Executive Director
+    * Repo: Executive Council only
+* Mailing list (listserv)
+  - executive-council@carpentries.org
+* Executive Council Google Calendar
+
+Incoming Executive Council members should be granted access to these resources in January. Outgoing members' access to these resources should be removed in February.
+
+Additionally, The Carpentries' website that includes the [Executive Council Members/Officers](http://static.carpentries.org/governance/) should be updated.
+
+#### Transfer of member responsibilities
+
+The following Executive Council roles should be assigned at the February meeting (these require formal voting by Executive Council members):
+
+* Officer positions:
+  * Chair
+  * Vice Chair
+  * Secretary
+  * Treasurer
+* Committee representatives (these may continue from previous terms as applicable):
+  * 2 x 2 Committee representatives
+  * CoC representative
+  * Representatives to Community Initiatives (CI)
+
+----
+
+Original sources:
+
+FIXME: remove some/all of the information from these resources and point to this page instead.
+
+* [x] https://github.com/carpentries-ec/conversations_ec_ed/blob/master/guide.md
+* [x] https://github.com/carpentries-ec/conversations_ec_ed/blob/master/README.md
+* [x] https://github.com/carpentries/executive-council-info
+* [x] https://github.com/carpentries/executive-council-info/blob/master/process/EC_transition.md
+* [x] https://github.com/carpentries/executive-council-info/blob/master/process/roles_responsibilities.md
+* [x] https://github.com/carpentries/executive-council-info/blob/master/process/timeline.md

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -18,16 +18,6 @@ there are three ways for communicating with Executive Council Members:
 2. **Send us an [email](mailto:carpentries-executive-council@carpentries.org).** This is appropriate for communicating directly with the Executive Council but not the rest of our community.
 3. **Submit [this form](https://docs.google.com/forms/d/e/1FAIpQLScdo7AlYfeQN-z5dnO-p8KVI8t17kQUc1VH-Cvrlga5txIwCA/viewform?usp=sf_link).** This is preferable if you would like confidential communication with the Executive Council, or if you would like to remain anonymous.
 
-
-### Elections
-
-Details about how Executive Council Members are elected and their terms of service are available in the [bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#nominations-and-elections). Elections are currently administered by an Executive Council Member (who is not up for re-election) via [ElectionBuddy](https://electionbuddy.com).
-
-A checklist for the Executive Council election process is available as a
-[Google Doc](https://docs.google.com/document/d/1qg__La6vsBfw2vEO22ftalIOdnUsvZ1CGldz1Em3zPM/edit?usp=sharing).
-An overview of whose council member's seats are up for (re-)election
-can be found in a [Google Sheet](https://docs.google.com/spreadsheets/d/1OJQr9HMdfQ0AEwBviajTlrQuhIIE2Zu4b_g-b77aB2s/edit?usp=sharing).
-
 ### The Carpentries Executive Council Documentation
 
 The information below describes all procedures, routines and resources
@@ -41,7 +31,7 @@ restricted to Executive Council members.
 We wish to be as transparent as we can,
 but sometimes we need to choose to withhold information from others.
 
-[from https://github.com/carpentries/executive-council-info/blob/master/process/roles_responsibilities.md]
+<!--From https://github.com/carpentries/executive-council-info/blob/master/process/roles_responsibilities.md]-->
 
 #### Responsibilities of all Executive Council Members
 
@@ -96,14 +86,14 @@ We use two mailing lists:
 The Executive Council generally meets once monthly (we are required to hold at least 10 meetings a year, either in person or online). Smaller groups of Executive Council members may hold additional meetings when needed.
 
 - [Publicly available meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes)
-- [Meeting conduct](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit?usp=sharing): how we prepare for and conduct regular meetings
-- [Agendas and minutes directory](https://drive.google.com/drive/folders/1iaDOmMPxkHtkHH-wAHK_LPNmNSNjynrN): we use a single document for meeting agendas/minutes for the entire year (meetings from February - January)
-- Scheduling through [Google calendar](https://calendar.google.com/calendar/ical/q7j1ftdldoaapso2on44qrdnps%40group.calendar.google.com/private-426a931882cc901bd08f0f49ee2d0bb4/basic.ics)
+- [Meeting conduct](https://docs.google.com/document/d/195omPpTOAnwNsUCqbH6S7Wpt9WDqU5joQKGMofTYDmg/edit?usp=sharing)<sup>*</sup>: how we prepare for and conduct regular meetings
+- [Agendas and minutes directory](https://drive.google.com/drive/folders/1iaDOmMPxkHtkHH-wAHK_LPNmNSNjynrN)<sup>*</sup>: we use a single document for meeting agendas/minutes for the entire year (meetings from February - January)
+- Scheduling through [Google calendar](https://calendar.google.com/calendar/ical/q7j1ftdldoaapso2on44qrdnps%40group.calendar.google.com/private-426a931882cc901bd08f0f49ee2d0bb4/basic.ics)<sup>*</sup>
 - Executive Council members are invited to attend the Core Team meetings whenever they desire
 
 ### Finances
 
-See the [Finance folder](https://drive.google.com/drive/folders/1521cY9O-ud5UahP9IM0BoxFAvZDspx9t) in Google Drive
+See the [Finance folder](https://drive.google.com/drive/folders/1521cY9O-ud5UahP9IM0BoxFAvZDspx9t)<sup>*</sup> in Google Drive
 
 ### GitHub
 
@@ -113,19 +103,19 @@ We maintain multiple repositories with variable permissions (some public, some r
 
 This is a GitHub organisation 'owned' by The Carpentries Core Team. Executive council members have access, as well as members of the Core Team and some community members
 
-https://github.com/carpentries/executive-council-info
+<https://github.com/carpentries/executive-council-info>
 
 * *public* repository
 * used to publish information intended for the community, such as our monthly meeting minutes
 
-https://github.com/carpentries-ec/conversations_ec_ed
+<https://github.com/carpentries-ec/conversations_ec_ed><sup>*</sup>
 
 * *private* repository. Executive council members have access, as well as the Executive Director
 * used for
     * off-meeting discussions and voting, through the issue functionality
     * storing relevant information that needs to be private to the world, and necessary or OK for the Executive Director or the Core Team to have access to
 
-https://github.com/carpentries/executive-council
+<https://github.com/carpentries/executive-council><sup>*</sup>
 
 * *private* repository
 * used for discussions between Executive Council and Executive Director that require broader direct feedback from the Core Team
@@ -135,12 +125,12 @@ https://github.com/carpentries/executive-council
 
 This is a GitHub organisation 'owned' by the Executive Council, used for information or documents that *only* Executive Council members should have access to. Optionally, the Executive Director can be given access by inviting them as collaborator.
 
-https://github.com/carpentries-ec/conversations_ec_ed
+<https://github.com/carpentries-ec/conversations_ec_ed><sup>*</sup>
 
 * *private* repository, only Executive Council and Executive Director have access (not the Core Team)
 * used to discuss issues between Executive Council and Executive Director outside of the Executive Council monthly meetings
 
-https://github.com/carpentries-ec/minutes-private
+<https://github.com/carpentries-ec/minutes-private><sup>*</sup>
 
 * *private* repository, *only Executive Council* (not Executive Director or the Core Team) have access
 * used for
@@ -150,18 +140,18 @@ https://github.com/carpentries-ec/minutes-private
     * hiring of a new Executive Director
     * salary discussions/decisions
 
-https://github.com/carpentries-ec/financeviz
+<https://github.com/carpentries-ec/financeviz><sup>*</sup>
 
 * *private* repository, Executive Council, Executive Director and the Core Team have access
 * used for visualizations and plots for communicating The Carpentries finances
 
 ### Google Drive
 
-We use a private Google Drive folder called ['Executive Council'](https://drive.google.com/drive/folders/1Ss6oh2vfLc_pE8xk9UpOh9UUwSpDBr2g). See its [README](https://docs.google.com/document/d/1wYSRcD2504Xxpl9TlSerexIh6z5kBkq2CVbP2eofl4o/edit_) for orientation to contents.
+We use a private [Google Drive folder](https://drive.google.com/drive/folders/1Ss6oh2vfLc_pE8xk9UpOh9UUwSpDBr2g)<sup>*</sup>. See its [README](https://docs.google.com/document/d/1wYSRcD2504Xxpl9TlSerexIh6z5kBkq2CVbP2eofl4o/edit_) for orientation to contents.
 
 ### Yearly Timeline
 
-[From https://github.com/carpentries/executive-council-info/blob/master/process/timeline.md]
+<!--From https://github.com/carpentries/executive-council-info/blob/master/process/timeline.md]-->
 
 Additional annual tasks:
 
@@ -238,9 +228,20 @@ Additional recurring tasks:
 * Review and discussion of strategic plan activities
 
 
+### Elections
+
+Details about how Executive Council Members are elected and their terms of service are available in the [bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#nominations-and-elections). Elections are currently administered by an Executive Council Member (who is not up for re-election) via [ElectionBuddy](https://electionbuddy.com).
+
+A checklist for the Executive Council election process is available as a
+[Google Doc](https://docs.google.com/document/d/1qg__La6vsBfw2vEO22ftalIOdnUsvZ1CGldz1Em3zPM/edit?usp=sharing)<sup>*</sup>.
+
+An overview of whose council member's seats are up for (re-)election
+can be found in a [Google Sheet](https://docs.google.com/spreadsheets/d/1OJQr9HMdfQ0AEwBviajTlrQuhIIE2Zu4b_g-b77aB2s/edit?usp=sharing)<sup>*</sup>.
+
+
 ### Transitions between Executive Councils
 
-[From https://github.com/carpentries/executive-council-info/blob/master/process/EC_transition.md]
+<!--From https://github.com/carpentries/executive-council-info/blob/master/process/EC_transition.md]-->
 
 The transfer of responsibilities to the incoming Executive Council includes
 
@@ -248,7 +249,7 @@ The transfer of responsibilities to the incoming Executive Council includes
 * [updating access to resources](#access-to-resources)
 * [selecting members to serve in specific roles](#transfer-of-member-responsibilities)
 
-A checklist for the transition process can be found as a [Google Doc](https://docs.google.com/document/d/1rMoTIOWiMMExe_WzHrRv3Ye8Yra5WyTas5zAOdAbRDA/edit?usp=sharing).
+A checklist for the transition process can be found as a [Google Doc](https://docs.google.com/document/d/1rMoTIOWiMMExe_WzHrRv3Ye8Yra5WyTas5zAOdAbRDA/edit?usp=sharing)<sup>*</sup>.
 
 
 #### Onboarding new Executive Council members
@@ -300,8 +301,10 @@ The following Executive Council roles should be assigned at the February meeting
   * CoC representative
   * Representatives to Community Initiatives (CI)
 
-----
+<sup>*</sup>Access to this link is restricted to Executive Council members.
 
+
+<!--
 Original sources:
 
 FIXME: remove some/all of the information from these resources and point to this page instead.
@@ -312,3 +315,5 @@ FIXME: remove some/all of the information from these resources and point to this
 * [x] https://github.com/carpentries/executive-council-info/blob/master/process/EC_transition.md
 * [x] https://github.com/carpentries/executive-council-info/blob/master/process/roles_responsibilities.md
 * [x] https://github.com/carpentries/executive-council-info/blob/master/process/timeline.md
+
+-->


### PR DESCRIPTION
The executive Council has quite som documentation available, but this information is spread over several GitHub pages and Google docs. In the spirit of transparency, we would like to add this information to the Carpentries Handbook, in other words, make it public. (note that some of the pages this information links to are still private to EC members). In addition, we thereby condense our documentation to a single page (with one appendix) to make it easier for new (and current) EC members to find what they need.

This PR adds these two pages.
