### PR TITLE
Small improvements to the EC documentation

### DIFF
--- a/topic_folders/governance/executive-council-officers.md
+++ b/topic_folders/governance/executive-council-officers.md
@@ -99,11 +99,3 @@ Practical information for the Treasurer role can be found in a <u>Google Doc</u>
 
 
 <sup>*</sup>Access to this information is restricted to Executive Council members.
-
-<!--
-Original sources:
-
-- [Chair](https://docs.google.com/document/d/1bW2TqnFrT-pSlASZvtRkJ89WsbeCGDoETpEXUkHGLyI/edit)
-- [Vice Chair](https://docs.google.com/document/d/1mjsv0bVc6TlVSuMS0Fp3KTtSWglEULvP4u_ngpP73rU/edit)
-- [Treasurer](https://docs.google.com/document/d/1i7BX7PEU9kF3fNLh7aD3qD0Ro3bKwdIzqL9UoglGZTc/edit#heading=h.r2lkwgs29qo0)
--->

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -119,13 +119,6 @@ This is a GitHub organisation 'owned' by The Carpentries Core Team. Executive co
 * used to publish information intended for the community, such as our monthly meeting minutes
 * also used for voting on our our motions (our decisions)
 
-<https://github.com/carpentries-ec/conversations_ec_ed><sup>*</sup>
-
-* *private* repository. Executive council members have access, as well as the Executive Director
-* used for
-    * off-meeting discussions and voting, through the issue functionality
-    * storing relevant information that needs to be private to the world, and necessary or OK for the Executive Director or the Core Team to have access to
-
 <https://github.com/carpentries/executive-council><sup>*</sup>
 
 * *private* repository
@@ -138,8 +131,11 @@ This is a GitHub organisation 'owned' by the Executive Council, used for informa
 
 <https://github.com/carpentries-ec/conversations_ec_ed><sup>*</sup>
 
-* *private* repository, only Executive Council and Executive Director have access (not the Core Team)
-* used to discuss issues between Executive Council and Executive Director outside of the Executive Council monthly meetings
+* *private* repository. Executive council members have access, as well as the Executive Director (but not the Core Team)
+* used to
+  * discuss issues between Executive Council and Executive Director outside of the Executive Council monthly meetings
+  * storing relevant information that needs to be private to the world, and necessary or OK for the Executive Director to have access to
+
 
 <https://github.com/carpentries-ec/minutes-private><sup>*</sup>
 

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -117,6 +117,7 @@ This is a GitHub organisation 'owned' by The Carpentries Core Team. Executive co
 
 * *public* repository
 * used to publish information intended for the community, such as our monthly meeting minutes
+* also used for voting on our our motions (our decisions)
 
 <https://github.com/carpentries-ec/conversations_ec_ed><sup>*</sup>
 

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -310,17 +310,3 @@ The following Executive Council roles should be assigned at the February meeting
   * Representatives to Community Initiatives (CI)
 
 <sup>*</sup>Access to this information is restricted to Executive Council members.
-
-<!--
-Original sources:
-
-FIXME: remove some/all of the information from these resources and point to this page instead.
-
-* [x] https://github.com/carpentries-ec/conversations_ec_ed/blob/master/guide.md
-* [x] https://github.com/carpentries-ec/conversations_ec_ed/blob/master/README.md
-* [x] https://github.com/carpentries/executive-council-info
-* [x] https://github.com/carpentries/executive-council-info/blob/master/process/EC_transition.md
-* [x] https://github.com/carpentries/executive-council-info/blob/master/process/roles_responsibilities.md
-* [x] https://github.com/carpentries/executive-council-info/blob/master/process/timeline.md
-
--->


### PR DESCRIPTION
* removes the (commented-out) original sources of the EC documentation
* clarifies which repository is used for voting on motions
* fixes a mistake in repository descriptions