### PR TITLE
Add redirect language

### DIFF
--- a/topic_folders/instructor_training/email_templates_admin.md
+++ b/topic_folders/instructor_training/email_templates_admin.md
@@ -159,6 +159,9 @@ Best,
 
 ##### Invitation to Open Training Applicants
 
+NOTE: This template is for internal use by The Carpentries Core Team and contains language specific to our Open Instructor Training sponsorship program.
+Member contacts looking to invite trainees to register through a membership should use [this template](https://docs.carpentries.org/topic_folders/instructor_training/email_templates_admin.html#initial-trainee-contact-email-from-member-site-to-their-prospective-trainees-online-training) instead.
+
 SUBJECT: Invitation to join The Carpentries Instructor Training
 
 Dear future Carpentries Instructor, 


### PR DESCRIPTION
Temporary solution as @maneesha looks at reorganizing templates for clarity on internal vs community applications. Addresses an instance of inappropriate adoption by a member noted on helpscout by @ErinBecker. 

There might be a better way to format this within-handbook link?

