### PR TITLE
add Incubator Lesson Spotlight info

### DIFF
--- a/topic_folders/lesson_development/index.rst
+++ b/topic_folders/lesson_development/index.rst
@@ -11,5 +11,4 @@ For more information on lesson development with The Carpentries, please visit `T
    bug_bbq.md
    lesson_release.md
    email_templates.md
-
-   
+   spotlight.md

--- a/topic_folders/lesson_development/spotlight.md
+++ b/topic_folders/lesson_development/spotlight.md
@@ -1,0 +1,53 @@
+## The Carpentries Incubator Lesson Spotlight
+
+The Incubator Lesson Spotlight is a regular feature in
+The Carpentries blog and newsletter,
+highlighting a lesson currently under community development.
+The purpose of the Spotlight series is to raise the visibility of that lesson
+among the broader community,
+and to encourage community members to contribute to
+the further development of that lesson.
+
+Any lesson in [The Carpentries Incubator][incubator] is eligible to be included
+in the series, regardless of the stage of development that lesson is currently in.
+It is a good way for lessons in the early stages of development
+to attract new collaborators,
+and for those in later stages
+to invite others to informally review the lesson
+and to try teaching the material.
+
+**If you are a developer of a lesson in The Carpentries Incubator,
+you can submit your lesson to be featured in
+the series by filling in
+[the Incubator Lesson Spotlight content submission form][ils-form]**.
+
+In the form, you will be asked to provide
+some basic details of the lesson and your collaborators,
+some information about the objectives and the history of the lesson,
+and a description of how The Carpentries community can best contribute
+to its ongoing development.
+This information will be used by the Core Team
+to create a post for The Carpentries blog,
+an item for the Carpentries Clippings newsletter,
+and related posts to social media.
+When the blog post has been drafted,
+a pull request will be opened to add that post to the website.
+You will be tagged for a (optional) review of this pull request
+before it is published.
+
+Incubator Lesson Spotlight features are intended to raise the visibility of
+the lesson and to encourage other community members to get involved in its
+further development,
+so it is best to think about how you can prepare your lesson for new contributors
+before the feature is published.
+This might mean labelling existing issues
+(e.g. to appear on [the Help Wanted page][help-wanted])
+or creating new ones,
+making sure that your CONTRIBUTING.md is up-to-date,
+and/or planning publication of the Spotlight feature to fit with a relatively quiet
+period in your schedule so that you can respond promptly
+to any new issues and pull requests.
+
+[help-wanted]: https://carpentries.org/help-wanted-issues/
+[ils-form]: https://docs.google.com/forms/d/e/1FAIpQLScJimGMtzqAFE-Tii-LvbfGZqtKj0OC4ken7_Qdlta8uZXAUA/viewform
+[incubator]: https://github.com/carpentries-incubator/


### PR DESCRIPTION
Adding a description of the Incubator Lesson Spotlight series and guidance for developers about when and how to submit their lesson to be featured in the series.