### PR TITLE
Update financial reporting timeline

### DIFF
--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -179,7 +179,7 @@ Additional recurring tasks:
 * Solicit nominations for Executive Council officers
 * Suggest annual goals for new Executive Council
 * Assess availability of incoming Executive Council Members for in-person meeting
-* Review Q4 financial report
+* Review November financials
 * Publish Q4 Code of Conduct Transparency Report
 
 #### February
@@ -188,35 +188,41 @@ Additional recurring tasks:
 * Select new officers
 * Select Executive Council liason to Code of Conduct Committee
 * Finalise annual goals for Executive Council
+* Review December & Q4 financial report
 
 #### March
 * Review and discussion of strategic plan activities
-* Review draft financial report for community (the draft may first be available early April)
+* Review January financials
 
 #### April
-* Review Q1 financial report
+* Review draft of annual financial report
+* Review February financials
 * Publish Q1 Code of Conduct Transparency Report
 
 #### May
+* Review March financials & Q1 financial report
 
 #### June
+* Review April financials
 * Review and discussion of strategic plan activities
 
 #### July
-* Review Q2 financial report
+* Review May financials
 * Publish Q2 Code of Conduct Transparency Report
 
 #### August
+* Review June & Q2 financial report
 
 #### September
 * Assign individuals to reassess bylaws (required in even-numbered years, due in November)
 * Review and discussion of strategic plan activities
+* Review July financials
 
 #### October
 * Assess desired skills for incoming Executive Council members
 * Announce opening of self-nomination for Executive Council
 * Solicit nominees for community awards
-* Review Q3 financial report
+* Review August financials
 * Publish Q3 Code of Conduct Transparency Report
 
 #### November
@@ -225,6 +231,7 @@ Additional recurring tasks:
 * Nominations for Executive Council elections close (at start of first community call)
 * Community call for Executive Council nominees
 * Vote on reassessed bylaws
+* Review September & Q3 financial report
 
 #### December
 * Announce community award winners
@@ -235,6 +242,7 @@ Additional recurring tasks:
 * Announcement of the new Executive Council
 * Start organising dates for face-to-face meeting in first half of year
 * Review and discussion of strategic plan activities
+* Review October financials
 
 
 ### Elections

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -179,7 +179,6 @@ Additional recurring tasks:
 * Solicit nominations for Executive Council officers
 * Suggest annual goals for new Executive Council
 * Assess availability of incoming Executive Council Members for in-person meeting
-* Review November financials
 * Publish Q4 Code of Conduct Transparency Report
 
 #### February
@@ -188,41 +187,35 @@ Additional recurring tasks:
 * Select new officers
 * Select Executive Council liason to Code of Conduct Committee
 * Finalise annual goals for Executive Council
-* Review December & Q4 financial report
+* Review Q4 financial report
 
 #### March
 * Review and discussion of strategic plan activities
-* Review January financials
 
 #### April
 * Review draft of annual financial report
-* Review February financials
 * Publish Q1 Code of Conduct Transparency Report
 
 #### May
-* Review March financials & Q1 financial report
+* Review Q1 financial report
 
 #### June
-* Review April financials
 * Review and discussion of strategic plan activities
 
 #### July
-* Review May financials
 * Publish Q2 Code of Conduct Transparency Report
 
 #### August
-* Review June & Q2 financial report
+* Review Q2 financial report
 
 #### September
 * Assign individuals to reassess bylaws (required in even-numbered years, due in November)
 * Review and discussion of strategic plan activities
-* Review July financials
 
 #### October
 * Assess desired skills for incoming Executive Council members
 * Announce opening of self-nomination for Executive Council
 * Solicit nominees for community awards
-* Review August financials
 * Publish Q3 Code of Conduct Transparency Report
 
 #### November
@@ -231,7 +224,7 @@ Additional recurring tasks:
 * Nominations for Executive Council elections close (at start of first community call)
 * Community call for Executive Council nominees
 * Vote on reassessed bylaws
-* Review September & Q3 financial report
+* Review Q3 financial report
 
 #### December
 * Announce community award winners
@@ -242,7 +235,6 @@ Additional recurring tasks:
 * Announcement of the new Executive Council
 * Start organising dates for face-to-face meeting in first half of year
 * Review and discussion of strategic plan activities
-* Review October financials
 
 
 ### Elections


### PR DESCRIPTION
We are on a 2 month delayed reporting system. CI provides us information for each month at the end of the following month, so the earliest we can report this information to the EC will be at their meeting 2 months later. I have included monthly and quarterly reporting dates, as well as our goal for the draft of the annual financial report. Please feel free to adjust the level of detail, remove the monthly reporting, etc.


