### PR TITLE
insert missing line break

### DIFF
--- a/topic_folders/governance/task-force-policy.md
+++ b/topic_folders/governance/task-force-policy.md
@@ -34,6 +34,7 @@ Each task force shall have a folder in the [Carpentries Task Forces GitHub repos
 * [Task Force Charter](https://github.com/carpentries/task-forces/blob/master/task-force-charter-template.md)
 * Meeting notes or minutes
 * Task Force report 
+
 The task force chair is responsible for updating this information as necessary.
 
 ### Internal Documentation


### PR DESCRIPTION
fixes a problem where a bullet point list was being merged with the subsequent paragraph.