### PR TITLE
Add guidance for running lesson pilot workshops

### DIFF
--- a/topic_folders/lesson_development/index.rst
+++ b/topic_folders/lesson_development/index.rst
@@ -9,6 +9,7 @@ For more information on lesson development with The Carpentries, please visit `T
 
    lesson_development_roles.md
    lesson_sprint_recommendations.md
+   lesson_pilots.md
    bug_bbq.md
    lesson_release.md
    email_templates.md

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -101,7 +101,7 @@ If you are hosting a pilot of a lesson in the Incubator,
 we ask that you **first** try to find Instructors for pilot workshops yourself.
 Often, hosts are able to recruit certified Instructors from their local
 community
-with relevant knowledge of the lesson topic
+with relevant knowledge of the lesson topic,
 but in some cases this will not be possible.
 If you wish to recruit Instructors for a pilot workshop,
 try putting a call out on

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -116,7 +116,7 @@ for assistance.
 [The Carpentries workshop webpage template](https://github.com/carpentries/workshop-template)
 supports the creation of webpages for pilot workshops.
 See [the Customisation page of the template documentation](https://carpentries.github.io/workshop-template/customization/#configuration-file-_configyml)
-for details of how to configure the webpage for a pilot workshop.
+for instructions on how to configure the webpage for a pilot workshop.
 
 The Carpentries does not currently track pilot workshops in the same
 way as workshops teaching our official lessons,

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -108,7 +108,7 @@ try putting a call out on
 [local/regional community mailing lists](https://carpentries.topicbox.com/groups),
 any relevant channels on [The Carpentries Slack workspace](https://carpentries.org/connect/) (the lesson authors may be able to direct you to these),
 and/or [by publishing a post on our blog](https://docs.carpentries.org/topic_folders/communications/guides/submit_blog_post.html).
-Please do not post calls for Instructors to the general channel on Slack, or the discuss and instructors lists on TopicBox: any messages to recruit Instructors will be removed from those channels. If after taking these steps, you find that you need help finding Instructors for your lesson pilot, you can [contact incubator@carpentries.org](mailto:incubator@carpentries.org)
+Please do not post calls for Instructors to the general or instructors channel on Slack, or the discuss and instructors lists on TopicBox: any messages to recruit Instructors will be removed from those channels. If after taking these steps, you find that you need help finding Instructors for your lesson pilot, you can [contact incubator@carpentries.org](mailto:incubator@carpentries.org)
 for assistance.
 
 #### Creating a Pilot Workshop Webpage

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -62,6 +62,29 @@ or if you have any questions about the lesson pilot process for
 lessons in The Carpentries Incubator,
 you can [contact incubator@carpentries.org](mailto:incubator@carpentries.org).
 
+#### Collecting Feedback on the Lesson
+
+Feedback from learners will be a valuable source of information
+and suggestions about how your lesson could be further improved after the pilot.
+The standard Carpentries pre- and post-workshop surveys
+do not support lesson pilots
+so you will need to create your own surveys to send out before/after a pilot workshop.
+Although surveys for pilot workshops will frequently include questions
+that are specific to the particular lesson being trialled,
+there are some standard feedback questions that can be asked after a pilot
+to assess the design and flow of the lesson.
+This [template post-pilot workshop survey](https://docs.google.com/forms/d/1OGCQBotD2nOJkc7KpFZLhFfb3EBcxEDwHz_3p48qz3U/template/preview)
+can be copied and adapted to suit the needs of your lesson,
+and shared with learners in place of the standard post-workshop survey.
+
+It is also important to gather information about the lesson
+while it is being taught.
+Check
+[the Lesson Life Cycle chapter of The Carpentries Curriculum Development Handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html#field-testing-alpha-stage)
+for a list of things to take note of during the pilot workshop.
+We recommend assigning a specific person or people with responsibility
+to keep track of these points, e.g. an Instructor or Helper.
+
 ### Information for Hosts
 
 #### Recruiting Instructors for Beta Pilots

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -69,7 +69,7 @@ The standard Carpentries pre- and post-workshop surveys
 do not support lesson pilots
 so you will need to create your own surveys to send out before/after a pilot workshop.
 Although surveys for pilot workshops will frequently include questions
-that are specific to the particular lesson being trialled,
+that are specific to the particular lesson being piloted,
 there are some standard feedback questions that can be asked after a pilot
 to assess the design and flow of the lesson.
 This [template post-pilot workshop survey](https://docs.google.com/forms/d/1OGCQBotD2nOJkc7KpFZLhFfb3EBcxEDwHz_3p48qz3U/template/preview)

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -81,7 +81,7 @@ while it is being taught.
 Check
 [the Lesson Life Cycle chapter of The Carpentries Curriculum Development Handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html#field-testing-alpha-stage)
 for a list of things to take note of during the pilot workshop.
-We recommend assigning a specific person or people with responsibility
+We recommend assigning a specific person or people
 to keep track of these points, e.g. an Instructor or Helper.
 
 ### Information for Hosts

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -1,0 +1,90 @@
+## Lesson Pilot Workshops
+
+### Purpose
+
+Teaching a lesson for the first time is very rewarding
+but the experience of the Instructors and Learners also
+identifies opportunities to address and further clarify
+parts of the content.
+This makes these early runs through a lesson,
+which we refer to as _lesson pilots_,
+crucial milestones in the development of a high-quality lesson.
+As well as teaching new and exciting skills to learners,
+the additional purpose of pilot workshops is to collect information
+and feedback that can be used to polish content
+and make the lesson more reusable by other Instructors
+e.g. by recording accurate timings for episodes and exercises,
+expanding Instructor Notes, etc.
+
+#### Alpha and Beta Pilots
+
+The lesson development process includes pilot workshops at
+two different stages, which we refer to as _alpha_ and _beta_ pilots.
+Alpha pilots are the first workshops where the lesson is taught,
+almost always by some or all of the original developers of the lesson.
+
+After the feedback from these alpha pilots has been used to improve
+the lesson, it can enter the beta stage, where other Instructors -
+who did not have a major part in the previous development of the lesson -
+teach it and provide feedback.
+
+For more information about these pilots,
+and the requirements for piloting official Carpentries lessons,
+see [the Lesson Life Cycle chapter of The Carpentries Curriculum Development Handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html).
+
+### Information for Lesson Developers
+
+#### Finding Hosts for Beta Pilots
+
+If you are developing a new official Carpentries lesson -
+a lesson developed based on prior agreement with The Carpentries,
+intended to become another lesson/curriculum offered
+in centrally-organised workshops -
+[the Curriculum Team](mailto:team@carpentries.org) will help you
+find hosts and Instructors for pilot workshops.
+
+If you are developing a lesson in The Carpentries Incubator,
+we encourage you to try to find hosts for pilot workshops yourself.
+You can do this by putting out a call for hosts via
+[the `discuss` TopicBox list](https://carpentries.topicbox.com/groups),
+[the `general` channel on The Carpentries Slack workspace](https://carpentries.org/connect/),
+[by publishing a post on our blog](https://docs.carpentries.org/topic_folders/communications/guides/submit_blog_post.html),
+and/or by any other communications channel that you think appropriate
+(e.g. the mailing list of a specific community likely to be interested in the lesson topic).
+You may find this
+[template blog post](https://docs.google.com/document/d/1z8QmxDIiew-p1d8aLzXa0vt0FLUHNtK3oS3tucyrRsI/edit?usp=sharing)
+and/or this
+[template email message](https://docs.google.com/document/d/1hHnm-Ljb_o_rNd9bvQ83ilq40KoGoEfMPTSrFS4QOj8/edit?usp=sharing)
+helpful starting points.
+If after taking these steps,
+you find that you need help finding hosts to pilot your lesson,
+or if you have any questions about the lesson pilot process for
+lessons in The Carpentries Incubator,
+you can [contact incubator@carpentries.org](mailto:incubator@carpentries.org).
+
+### Information for Hosts
+
+#### Recruiting Instructors for Beta Pilots
+
+If you are hosting a pilot of a new official Carpentries lesson -
+a lesson developed based on prior agreement with The Carpentries,
+intended to become another lesson/curriculum offered
+in centrally-organised workshops -
+[the Curriculum Team](mailto:team@carpentries.org) will help you
+find Instructors for pilot workshops.
+
+The Carpentries is also keen to support the development and piloting
+of lessons in The Carpentries Incubator.
+If you are hosting a pilot of a lesson in the Incubator,
+we ask that you **first** try to find Instructors for pilot workshops yourself.
+Often, hosts are able to recruit certified Instructors from their local
+community
+with relevant knowledge of the lesson topic
+but in some cases this will not be possible.
+If you wish to recruit Instructors for a pilot workshop,
+try putting a call out on
+[local/regional community mailing lists](https://carpentries.topicbox.com/groups),
+any relevant channels on [The Carpentries Slack workspace](https://carpentries.org/connect/) (the lesson authors may be able to direct you to these),
+and/or [by publishing a post on our blog](https://docs.carpentries.org/topic_folders/communications/guides/submit_blog_post.html).
+Please do not post calls for Instructors to the general channel on Slack, or the discuss and instructors lists on TopicBox: any messages to recruit Instructors will be removed from those channels. If after taking these steps, you find that you need help finding Instructors for your lesson pilot, you can [contact incubator@carpentries.org](mailto:incubator@carpentries.org)
+for assistance.

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -64,7 +64,7 @@ you can [contact incubator@carpentries.org](mailto:incubator@carpentries.org).
 #### Collecting Feedback on the Lesson
 
 Feedback from learners will be a valuable source of information about
-and suggestions about how your lesson could be further improved after the pilot.
+and suggestions for how your lesson could be further improved after the pilot.
 The standard Carpentries pre- and post-workshop surveys
 do not support lesson pilots
 so you will need to create your own surveys to send out before/after a pilot workshop.

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -63,7 +63,7 @@ you can [contact incubator@carpentries.org](mailto:incubator@carpentries.org).
 
 #### Collecting Feedback on the Lesson
 
-Feedback from learners will be a valuable source of information
+Feedback from learners will be a valuable source of information about
 and suggestions about how your lesson could be further improved after the pilot.
 The standard Carpentries pre- and post-workshop surveys
 do not support lesson pilots

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -44,7 +44,6 @@ in centrally-organised workshops -
 find hosts and Instructors for pilot workshops.
 
 If you are developing a lesson in The Carpentries Incubator,
-we encourage you to try to find hosts for pilot workshops yourself.
 You can do this by putting out a call for hosts via
 [the `discuss` TopicBox list](https://carpentries.topicbox.com/groups),
 [the `general` channel on The Carpentries Slack workspace](https://carpentries.org/connect/),

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -111,3 +111,15 @@ any relevant channels on [The Carpentries Slack workspace](https://carpentries.o
 and/or [by publishing a post on our blog](https://docs.carpentries.org/topic_folders/communications/guides/submit_blog_post.html).
 Please do not post calls for Instructors to the general channel on Slack, or the discuss and instructors lists on TopicBox: any messages to recruit Instructors will be removed from those channels. If after taking these steps, you find that you need help finding Instructors for your lesson pilot, you can [contact incubator@carpentries.org](mailto:incubator@carpentries.org)
 for assistance.
+
+#### Creating a Pilot Workshop Webpage
+
+[The Carpentries workshop webpage template](https://github.com/carpentries/workshop-template)
+supports the creation of webpages for pilot workshops.
+See [the Customisation page of the template documentation](https://carpentries.github.io/workshop-template/customization/#configuration-file-_configyml)
+for details of how to configure the webpage for a pilot workshop.
+
+The Carpentries does not currently track pilot workshops in the same
+way as workshops teaching our official lessons,
+so you do not need to submit details of your workshop/webpage
+as you would when [hosting a self-organised workshop](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html#self-organised-workshop).

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -118,7 +118,20 @@ supports the creation of webpages for pilot workshops.
 See [the Customisation page of the template documentation](https://carpentries.github.io/workshop-template/customization/#configuration-file-_configyml)
 for instructions on how to configure the webpage for a pilot workshop.
 
-The Carpentries does not currently track pilot workshops in the same
-way as workshops teaching our official lessons,
-so you do not need to submit details of your workshop/webpage
-as you would when [hosting a self-organised workshop](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html#self-organised-workshop).
+If you are piloting a new official Carpentries lesson -
+a lesson developed based on prior agreement with The Carpentries,
+and which is intended to become another lesson/curriculum offered
+in centrally-organised workshops -
+please [register your pilot as a Self-Organised Workshop](https://amy.carpentries.org/forms/self-organised/).
+If you do not see the lesson/curriculum being piloted listed
+as one of the choices on that form,
+please contact [The Carpentries Core Team](mailto:team@carpentries.org).
+
+The Carpentries does not currently track pilot workshops
+for lessons in The Carpentries Incubator,
+so you do not need to submit details of your workshop to
+The Carpentries.
+Nevertheless, we strongly encourage you to create a workshop webpage
+and to communicate with the lesson authors
+so that they are aware of your pilot workshop and can benefit
+from the feedback you collect.

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -3,7 +3,7 @@
 ### Purpose
 
 Teaching a lesson for the first time is very rewarding
-but the experience of the Instructors and Learners also
+but the experience of the Instructors and learners also
 identifies opportunities to address and further clarify
 parts of the content.
 This makes these early runs through a lesson,

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -38,7 +38,7 @@ see [the Lesson Life Cycle chapter of The Carpentries Curriculum Development Han
 
 If you are developing a new official Carpentries lesson -
 a lesson developed based on prior agreement with The Carpentries,
-intended to become another lesson/curriculum offered
+and which is intended to become another lesson/curriculum offered
 in centrally-organised workshops -
 [the Curriculum Team](mailto:team@carpentries.org) will help you
 find hosts and Instructors for pilot workshops.

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -90,7 +90,7 @@ to keep track of these points, e.g. an Instructor or Helper.
 
 If you are hosting a pilot of a new official Carpentries lesson -
 a lesson developed based on prior agreement with The Carpentries,
-intended to become another lesson/curriculum offered
+and which is intended to become another lesson/curriculum offered
 in centrally-organised workshops -
 [the Curriculum Team](mailto:team@carpentries.org) will help you
 find Instructors for pilot workshops.

--- a/topic_folders/lesson_development/lesson_pilots.md
+++ b/topic_folders/lesson_development/lesson_pilots.md
@@ -44,7 +44,7 @@ in centrally-organised workshops -
 find hosts and Instructors for pilot workshops.
 
 If you are developing a lesson in The Carpentries Incubator,
-You can do this by putting out a call for hosts via
+you can recruit pilot hosts by putting out a call via
 [the `discuss` TopicBox list](https://carpentries.topicbox.com/groups),
 [the `general` channel on The Carpentries Slack workspace](https://carpentries.org/connect/),
 [by publishing a post on our blog](https://docs.carpentries.org/topic_folders/communications/guides/submit_blog_post.html),


### PR DESCRIPTION
This section provides guidance for community members who want to organise pilot workshops for a new lesson.