### PR TITLE
add link to maintainer onboarding curriculum

### DIFF
--- a/topic_folders/maintainers/maintainers.md
+++ b/topic_folders/maintainers/maintainers.md
@@ -40,7 +40,7 @@ in the README file in your lesson repository.
 
 ## How to Handle Issues
 
-[The Maintainer Onboarding curriculum](https://carpentries.github.io/maintainer-onboarding/02-skills/index.html) contains some guidelines for how to respond to community-submitted issues. 
+[The Maintainer Onboarding curriculum](https://carpentries.github.io/maintainer-onboarding/02-skills/) contains some guidelines for how to respond to community-submitted issues. 
 
 ## How to Get Help
 

--- a/topic_folders/maintainers/maintainers.md
+++ b/topic_folders/maintainers/maintainers.md
@@ -40,7 +40,7 @@ in the README file in your lesson repository.
 
 ## How to Handle Issues
 
-Information coming soon.
+[The Maintainer Onboarding curriculum](https://carpentries.github.io/maintainer-onboarding/02-skills/index.html) contains some guidelines for how to respond to community-submitted issues. 
 
 ## How to Get Help
 


### PR DESCRIPTION
Contributes to fixing https://github.com/carpentries/docs.carpentries.org/issues/48