### PR TITLE
IT Comms Overhaul: Member templates

### DIFF
--- a/topic_folders/instructor_training/email_templates_admin.md
+++ b/topic_folders/instructor_training/email_templates_admin.md
@@ -106,56 +106,6 @@ Best,
 
 [ sender name ]
 
-##### Initial Trainee Contact Email  (from member site to their prospective trainees - online training)
-
-SUBJECT: Invitation to become a certified Carpentries Instructor
-
-Dear [ name ],
-
-We are excited to announce that [ site name ] has become a member of
-The Carpentries!
-
-The Carpentries (https://carpentries.org) is a global group of 
-volunteers who develop and teach two-day, interactive, hands-on 
-workshops on essential computing and data skills that are not part
-of basic research training in most disciplines. 
-
-As part of our Carpentries membership, we are able to have
-[ number ] people from [ site name ] complete The Carpentries’ 
-instructor training program (https://carpentries.github.io/instructor-training/) and become certified Carpentries instructors.
-Certified instructors can teach Carpentries workshops (https://carpentries.org/workshops/), helping 
-us reach more people and build these skills across our community. 
-Instructors also have the opportunity to travel to teach Carpentries 
-workshops at other institutions around the globe. 
-
-I would like to invite you to you to become one of our Carpentries 
-instructors. Instructor training is held online via video-conference, 
-over two consecutive days. If you are interested in becoming a 
-Carpentries instructor, please register for one of the training 
-events listed here: 
-( https://carpentries.github.io/instructor-training/training_calendar/ ) 
-Please note you must use this code to register:  [ code ]. You 
-will also need to complete The Carpentries instructor training application 
-form using the same registration code: 
-https://amy.carpentries.org/forms/request_training/. This 
-application is a formality - you are guaranteed to be accepted into 
-the training program - but The Carpentries Core Team needs this 
-application in order to get your information for training into their
-system. 
-
-If you are not interested in becoming a Carpentries instructor, or 
-don’t have time - please let me know as soon as possible so that I 
-can offer this seat to another person. 
-
-We are all excited to grow our Carpentries community and look forward 
-to bringing you on board. 
-
-If you have any questions please contact me or The Carpentries team 
-at team@carpentries.org. 
-
-Best,
-
-[ sender name ] 
 
 ##### Invitation to Open Training Applicants
 

--- a/topic_folders/instructor_training/members_join.md
+++ b/topic_folders/instructor_training/members_join.md
@@ -6,7 +6,7 @@ The Program Manager will share the [member training process](https://carpentries
 
 The Program Manager will [share information](email_templates_admin.html#member-training-introductions) about the training with all participants, including a link to our application form and some pre-reading material.
 
-### Host Checklist
+### Online Instructor Training Host Checklist
 
 Our training events are typically offered using the Zoom videoconferencing platform.
 
@@ -23,4 +23,48 @@ Other things to be set up for the event include:
 * Allowing for break out space during the event. The training includes partner and small group activities. If the room is big enough this can be done in different corners of the room.  Otherwise, a hallway alcove or nearby office may be a good fit.
 
 
+### Trainee Recruitment Email (From Member Contact)
+
+Dear [ name ],
+
+We are excited to announce that [ site name ] has become a member of The Carpentries!
+
+[The Carpentries](https://carpentries.org) is a global community of volunteers who develop and teach interactive, hands-on workshops on computing and data skills, addressing basic training needs that are unmet in most disciplines.
+
+As part of our Carpentries membership, we can have [ number ] people from [ site name ] complete [The Carpentries’ Instructor Training program](https://carpentries.github.io/instructor.training/) and become certified Carpentries Instructors. 
+
+Certified Instructors can co-teach [Carpentries workshops](https://carpentries.org/workshops/) here at [ site name ], helping us reach more people and build these skills across our community. In addition, Carpentries Instructors also have the opportunity to teach as part of a team at other institutions in The Carpentries network, meeting others with similar skills who enjoy sharing them. Hosting institutions cover travel and expenses for volunteer Instructors teaching workshops in-person.
+
+[Service as a Carpentries Instructor is a voluntary activity. This service can support existing work responsibilities in a variety of roles. It also represents an opportunity for career development. Carpentries Instructors are sought after in a variety of academic and professional teaching roles. Participation as an Instructor builds skills as well as a track record in teaching while expanding your professional network.]
+
+The Carpentries Instructor Training is primarily focused on evidence-based teaching practices and does not include technical skills training. It is expected that trainees will have or will develop the technical skills necessary to guide learners through the entry level curricula for one or more [Data Carpentry](https://datacarpentry.org/lessons/), [Library Carpentry](https://librarycarpentry.org/lessons/), or [Software Carpentry](https://software-carpentry.org/lessons/) workshops. 
+
+If you are interested in being trained and certified as a Carpentries Instructor, please [ instructions to express interest or apply ] by [ deadline ].
+
+Please get in touch with questions! 
+
+
+### Selected Trainee Information Email (From Member Contact for pooled training events)
+SUBJECT: Invitation to become a certified Carpentries Instructor
+
+Dear [ name ],
+
+Thank you for your interest in Carpentries Instructor Training! I am pleased to be able to offer you an opportunity to be trained through our Carpentries membership. 
+
+Instructor Training events are held online via video conference, with schedule options including two full days or four half days. There are two steps to register: 
+
+1. Visit the [Instructor Training Calendar](https://carpentries.github.io/instructor-training/training_calendar/) and select an event. Click on the link to Eventbrite and use the following code: [ CODE ]. Please do not share this code.
+2. Complete The Carpentries’ [profile-creation form](https://amy.carpentries.org/forms/request_training/) using the same registration code: [ CODE ]. This allows The Carpentries to track your progress to certification. 
+
+You will receive more details about your training from The Carpentries (instructor.training@carpentries.org) one week prior to your event. Be sure to look out for this email, and check your spam filters. There is a small amount of preparation expected before the training as well as three short tasks involved in certification. To learn more, see the [Preparing for Training and Certification page](https://data-lessons.github.io/instructor-training/setup.html). 
+
+If anything comes up and you are no longer interested or able to participate, please let me know as soon as possible so that I can offer this seat to another person.
+
+We are all excited to grow our local Carpentries community and look forward to bringing you on board.
+
+If you have any questions, please contact me or The Carpentries Instructor Training team at instructor.training@carpentries.org.
+
+Best,
+
+[ sender name ]
 


### PR DESCRIPTION
This is a PR that should be merged before the others (as soon as it has been reviewed). Other items include links to content created by this PR. 

Removes existing template for members to use from "for administrators" section 
Adds 2 new templates for members to use to "for members" section
(incidentally: retitles "host checklist" to be more descriptive as we already have a different "host checklist" elsewhere)