### PR TITLE
Clarify lesson programs (Requires EC approval)

### DIFF
--- a/topic_folders/governance/bylaws.md
+++ b/topic_folders/governance/bylaws.md
@@ -11,7 +11,10 @@
 ## 2. Lesson Programs
 
 ### Overview
-Lesson Programs are collections of lessons which comprise one or more Carpentries workshops and the leadership guiding their development and implementation. The following requirements outline the general expectations associated with Lesson Programs; additional detail can be found in the [Lesson Program Policy](https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html).
+Lesson Programs are collections of lessons which comprise one or more Carpentries workshops and the leadership guiding their development and implementation. 
+As of 2021, The Carpentries Lesson Programs include [Data Carpentry](https://datacarpentry.org/), 
+[Library Carpentry](https://librarycarpentry.org/), and [Software Carpentry](https://software-carpentry.org/). 
+The following requirements outline the general expectations associated with Lesson Programs; additional detail can be found in the [Lesson Program Policy](https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html).
 
 ### Eligibility for Lesson Program Acceptance
 The Executive Council is responsible for assessing a prospective Lesson Program for acceptance into The Carpentries, which requires a majority vote. The Executive Director in coordination with relevant core team and Executive Council members will be responsible for:  developing and implementing policies related to Lesson Program incubation and assessing the ability of the Core Team and community to meet obligations associated with new Lesson Programs.


### PR DESCRIPTION
This is a clarification to the definition of Lesson Programs that was brought up during Trainer Leadership meeting 18 October 2021. In attendance include @masamiy and @sstevens2 from the EC. I know any changes to our bylaws require a majority vote from the EC. @sstevens2 could you please bring this to the EC for vote or propose a different place to make this clarification?