### PR TITLE
Removed "Scheduling Community Discussions" section and Zoom recording

### DIFF
--- a/topic_folders/instructor_development/community_discussions_workflow.md
+++ b/topic_folders/instructor_development/community_discussions_workflow.md
@@ -1,46 +1,6 @@
 ## Community Discussions Workflow
 
-This workflow was established for the [Instructor Development Committee Discussion Session Coordinator](https://docs.carpentries.org/topic_folders/instructor_development/instructor_development_committee.html#discussion-session-coordinator) to organise The Carpentries [Community Discussions](https://docs.carpentries.org/topic_folders/instructor_development/community_discussions.html). Between January 2020 and September 2020, this workflow will be managed by Angelique van Rensburg from Carpentries Core Team.
-
-### Scheduling Community Discussions
-
-- Review responses from the [Call for Community Discussions Facilitators](https://forms.gle/nDgJWUdpaH4gYP9c9) form.
-  - The [Call for Community Discussions Facilitators](https://forms.gle/nDgJWUdpaH4gYP9c9) form includes an integration which, when a form response is received, an e-mail is sent to The Carpentries Discussion Session Coordinator who should then open the attachment and review its contents.
-- Add potential Community Discussions to [the Etherpad](https://pad.carpentries.org/community-discussions).
-- If the Community Discussions Facilitator proposed a day/time for the community discussion they will be hosting, add that day/time to [the Etherpad](https://pad.carpentries.org/community-discussions) as TBD in this format:
-```
-Themed Discussion Sessions/#CarpentriesConversation
-DAY OF WEEK, MONTH DAY TIME
-TIME UTC
-Click here for your time zone:
-Topic:
-Description
-Host (name & email):
-Host questionnaire to be completed at the end of call: https://goo.gl/forms/iXkMQABmO6HROfCy1
-Co-host/notetaker (name & email):
-Attending (Name/Affiliation/Twitter):
-  Sharing an upcoming or past workshop? Please add the link to your workshop website along with your name.
-  Attending as part of the instructor checkout requirement? Please add your e-mail address and checkout along with your name.
-    1.
-    2.
-    3.
-Attendee questionnaire to be completed at the end of call: https://goo.gl/forms/uCeESfUUWsX5dpPu2
-```
-
-- Add potential Community Discussion to [the community calendar](https://carpentries.org/community/#community-events)
-  - If the Community Discussions Facilitator proposed a day/time for the community discussion, add that day/time to the community calendar in UTC and assign the Zoom Room [carpentries room 2](https://carpentries.zoom.us/my/carpentriesroom2) for the call. If they did not provide a time, include that question in your e-mail to them.
-- Add potential Community Discussion to the Community Discussions Page on the website
-  - Submit a PR to update the [Community Discussions page on The Carpentries website](https://carpentries.org/community_discussions/)
-  - The appropriate GitHub repository to submit your Pull Request to [is here](https://github.com/carpentries/carpentries.org/pulls). Add the new community discussion in the upcoming discussions section.
-- Contact potential Community Discussions Facilitator
-  - Send [a version of the following templated e-mail](https://docs.google.com/document/d/1Xag1PA5Ya2iEqpYTKjaKR9gh-JqhsS-yKiZaCAA9VUk/edit) to the individual who completed the form. Once the e-mail has been sent, highlight the row in the spreadsheet yellow indicating that you have contacted the individuals.
-- Communications Tasks
-	- Inform The Carpentries Core Team Liaisons about the Community Discussion by emailing `community@carpentries.org`.
-	- Draft tweets for Community Discussion
-    - Make a copy of [this template](https://docs.google.com/spreadsheets/d/1REIQrKnbFFgiNU0tjKLHLXARnIYaMIXlgZbmz8o5Boo/edit#gid=0) and draft tweets to spread the word about the Community Discussion.
-		- Send the tweet template to the Communications Manager by emailing `okhan@carpentries.org`.
-- Request Blog Post to Promote Community Discussion
-  - Remind facilitator to write a blog post to get the word out about the community discussion. [Here is a handy blog post drafting guide to help them get started](https://docs.carpentries.org/topic_folders/communications/submit_blog_post.html?highlight=blog%20posts)
+This workflow was established for the [Instructor Development Committee Discussion Session Coordinator](https://docs.carpentries.org/topic_folders/instructor_development/instructor_development_committee.html#discussion-session-coordinator) to organise The Carpentries [Community Discussions](https://docs.carpentries.org/topic_folders/instructor_development/community_discussions.html). This workflow will be managed by The Carpentries, Community Development Team.
 
 ### Scheduling Pre- and Post-Workshop Community Discussions
 
@@ -59,7 +19,6 @@ Attendee questionnaire to be completed at the end of call: https://goo.gl/forms/
 	- Identify someone to moderator the Community Discussion. This individual will:
     - Introduce the facilitator
     - Remind participants that we are following The Carpentries Code of Conduct
-    - Request permission from attendees to record the session.
     - Take notes during the discussion
     - Moderate Q&A
     - Facilitate breakout rooms


### PR DESCRIPTION
@acrall should we think about removing the Discussion wrap up too? @maneesha I also removed the part where we record community discussions. 
