### PR TITLE
Update Maintainer Onboarding documentation

### DIFF
--- a/topic_folders/maintainers/email_templates.md
+++ b/topic_folders/maintainers/email_templates.md
@@ -104,7 +104,7 @@ Hi team!
  
 Please join me in welcoming NUMBER new Maintainers to our group.
  
-NAMES, will be joining on in support of Library Carpentry lessons (LESSON NAMES, respectively). NAME is joining the Software Carpentry LESSON NAME Maintainer team. NAMES will be Data Carpentry lessons (LESSON NAMES, respectively). 
+NAMES, will be joining on in support of Library Carpentry lessons (LESSON NAMES, respectively), NAMES in support of Software Carpentry lessons (LESSON NAMES, respectively), and NAMES in support of Data Carpentry lessons (LESSON NAMES, respectively). 
  
 Welcome to the team NAMES!
  

--- a/topic_folders/maintainers/email_templates.md
+++ b/topic_folders/maintainers/email_templates.md
@@ -1,54 +1,159 @@
 ### Email Templates
 
-#### Response to Application
+#### Inviting new maintainers
 
 Hi {name},
 
-Thank you for your application. Your experience looks absolutely perfect for the position and we would be more than happy to have you on 
-the Maintainer team. I will be sending you an introductory email with the current Maintainers momentarily. Thank you again for volunteering 
-and welcome to the team!
+Subject: Welcome to The Carpentries Maintainer Onboarding!
+
+Dear {name},
+
+Thank you for applying to join The Carpentries Maintainer community. Your experience and community service goals are an excellent fit and we would love to have you on the Maintainer team. Welcome!
+
+I will share more information about the onboarding process, lesson assignments, and how to get connected up with your fellow Maintainers once I have the schedule ready. Please let me know if you have any questions. Looking forward to having you on the team!
+
+Best,
+{name}
+
+#### Application not accepted
+
+No template yet created. 
+
+#### Lesson assignment
+
+Subject: Schedule and lesson assignment for Maintainer Onboarding
+
+Dear {name}, 
+
+Thank you for providing your availability for Maintainer Onboarding. Based on your availability, I’ve signed you up for Session LETTER, which will be held from TIME UTC on DATE UTC.  I’ve sent you a Google Calendar invite, which should show up on your calendar using your local time zone, but please double check the time of the training by clicking this link: LINK. Connection information for the call is included in the calendar link and will be shared by email a week before the session.
+
+Other time slots are available, as shown below. Please let me know as soon as possible if you would prefer to attend a different session, as we’d like to keep each session roughly the same size. 
+
+Session A - DATE TIME - DATE TIME UTC (click here for your local time)
+Session B - DATE TIME - DATE TIME UTC  (click here for your local time)
+Session C - DATE TIME - DATE TIME UTC  (click here for your local time)
+
+Each three hour session will cover content found in our Maintainer Onboarding lesson. 
+
+Based on your interests, technical skillset, and our current needs for Maintainers, you are being invited to serve as a Maintainer for LESSON NAME AND LINK. If you have any concerns about this lesson assignment, or would like to request a different lesson, please let me know. Please take some time to get acquainted with the lesson before your onboarding. 
+
+Future announcements about Maintainer Onboarding will be sent via our mailing list and Slack channel. Please sign up for the mailing list on TopicBox and join the Maintainer-Onboarding-202X Slack channel via the sign-up link you will receive in a separate email. 
+
+After your onboarding session, I will formally introduce you to the other Maintainers for your lesson and will also provide information about how to stay connected with the Maintainer community on Slack, our mailing list, and through our monthly meetings. 
+
+Thank you again for joining the Maintainer community. I look forward to working with you!
+
+In service,
+{name}
+
+#### Available time slots
+ 
+Subject: Schedule for Maintainer Onboarding
+ 
+Dear {name},
+
+Thank you for providing your availability for Maintainer Onboarding. Based on your availability, I have not been able to schedule you into one of the available time slots. The available time slots are shown below. Please let me know if any other these times will work with your schedule, and if so, which you would prefer. I'll then send you a GCal invite and connection information.  
+
+Session A - DATE TIME - DATE TIME UTC (click here for your local time)
+Session B - DATE TIME - DATE TIME UTC (click here for your local time)
+Session C - DATE TIME - DATE TIME UTC (click here for your local time)
+ 
+Thank you again!
+
+In service,
+{name}
+
+
+#### Onboarding reminder
+
+Subject: Reminder email about onboarding schedule
+
+Hi all, 
+
+Just a quick reminder to folks who are signed up for Session A of onboarding that we will be meeting starting at TIME DATE (click this link to see start in your local time). 
+
+You don't need to read anything in preparation for the training, but if you're interested in checking out the onboarding curriculum, you can find it here:
+
+The Zoom link for our training is: LINK. This link should "just work" for you without entering a meeting ID or password.
+
+Please let me know if you have any questions. Looking forward to meeting you all soon!
 
 Best,
 {name}
 
 #### Introduction to co-Maintainers
 
-Subject: Welcome new Maintainer!  
+Subject: Welcome new Maintainer!
 
 CC Current lesson Maintainers
 
-Hi {names},  
+Hi {names},
 
-I would like to introduce {name}, who has just joined the {lesson name} Maintainer team. {name} has experience with {relevant things}. 
-{name} is also {other roles in the community}. They are excited to 
-lend a hand on the {lesson name} lesson and to be a part of this maintenance team. I will be setting {name} up with the appropriate GitHub 
-permissions in the next few days. It would be great if you all could arrange a meeting to discuss logistics and help {name} get oriented.
+I would like to introduce {name}, who has just completed Maintainer Onboarding and is now joining the {lesson name} Maintainer team. They are excited to lend a hand on the {lesson name} lesson and to be a part of this maintenance team. Please welcome {name} by introducing yourself and letting {name} know what channel(s) you prefer to be contacted on. 
+
 Please let me know if there is anything else you all need. Great to have you on the team {name}!
 
+Best, 
+{name}
+
+#### General introduction on Maintainers list
+
+Subject: Welcome new Maintainers!
+ 
+Hi team!
+ 
+Please join me in welcoming NUMBER new Maintainers to our group.
+ 
+NAMES, will be joining on in support of Library Carpentry lessons (LESSON NAMES, respectively). NAME is joining the Software Carpentry LESSON NAME Maintainer team. NAMES will be Data Carpentry lessons (LESSON NAMES, respectively). 
+ 
+Welcome to the team NAMES!
+ 
 Best,
 {name}
 
-#### Community information for new Maintainer
+#### Maintainer retiring
 
-Subject: Getting connected with the Maintainer community  
+Subject: Thank you for your service as a lesson Maintainer with The Carpentries!
 
-Hi {name},  
+Dear {name},
 
-Thank you again for joining the Maintainer team! I am excited to have you on board and wanted to give you some information about how to get
-connected up with the community. In addition to working directly with your lesson team, there are also opportunities to connect with and 
-learn from the broader Maintainer team. Please sign up for our mailing list on TopicBox 
-(https://carpentries.topicbox.com/groups/maintainers) and the maintainers channel on Slack (I have sent 
-you an invitation). Those two channels are the primary communication channels for Maintainers and will be where you see announcements 
-around technical changes, lesson releases, and other issues related to lesson maintenance. 
+Thank you for all of the work that you have done for The Carpentries community as a lesson Maintainer. Your service has been incredibly valuable to the community and to all workshop learners who have benefited from the high-quality lessons maintained by you and the rest of the Maintainer team.
 
-Please also "watch" the maintainer-RFCs GitHub repo (https://github.com/carpentries/maintainer-RFCs) and your lesson repo, so that you can
-keep up to date with issues and PRs in those repos. The maintainer-RFCs repo is where we hold discussion around issues relevant to the 
-broad Maintainers community. 
+You recently indicated that you would like to step down from the Maintainer role. To honor this request, I have removed you from the Maintainers private Slack channel and TopicBox list, as well as from the relevant GitHub team for your lesson. You are also no longer listed as a Maintainer on The Carpentries website. 
 
-Please also consider joining our monthly Maintainer community calls. You will find information about those meetings on our Etherpad 
-(https://pad.carpentries.org/maintainers) and on the community calendar (https://carpentries.org/community/#community-events).
+Please know that these changes are cosmetic and you have not lost your status as a trusted Maintainer for The Carpentries lesson materials. If at any point you would like to resume working as a Maintainer, please let me know or send an email to team@carpentries.org and we would be happy to reinstate you. 
 
-Please let me know what questions you have and welcome again to the team!
+I wish you all the best in your future endeavours and hope to continue seeing you around the community.
 
-Best,
+In service,
+{name}
+
+#### Inactive maintainer removal
+
+Subject: Removal from maintenance team for LESSON NAME
+
+Dear {name},
+
+In MONTH YEAR you were certified as a Maintainer for the LESSON NAME. Not seeing any activity from you on that repository in the past TIME, I am assuming you no longer want to be part of the maintenance team for this lesson. 
+
+You have been removed from the Maintainers private Slack channel and TopicBox list, as well as from the relevant GitHub team for your lesson. You are also no longer listed as a Maintainer on The Carpentries website. 
+
+If at any point you would like to resume serving as a Maintainer, please let me know or send an email to team@carpentries.org.
+
+I wish you all the best in your future endeavours and hope to continue engaging with you in The Carpentries community.
+
+In service,
+{name}
+
+#### Notification that co-Maintainer has been removed
+
+Subject: Co-Maintainer stepping down from LESSON NAME
+
+Dear {name},
+
+NAME has recently stepped down serving as a Maintainer for the LESSON NAME lesson, making you the sole acting Maintainer for this lesson. Our goal is to always have at least two active Maintainers for each lesson, and this lesson will be prioritized in the next round of recruitment for Maintainer Onboarding. In the meantime, please feel free to assign items to me for review and/or ping me in Slack or by email for anything you would like assistance with. MAINTAINER COMMUNITY LEAD (cc’d and @GITHUB HANDLE) is also available to provide some support as needed, in their role as Maintainer Community Lead. 
+
+Please let me know if you have any questions. Thank you for all that you do with and for The Carpentries community. 
+
+In Service,
 {name}

--- a/topic_folders/maintainers/maintainers.md
+++ b/topic_folders/maintainers/maintainers.md
@@ -70,7 +70,7 @@ the onboarding process.
 
 1. Identify lessons in need of additional maintenance support. This includes surveying current Maintainers using [a Google form](https://docs.google.com/forms/d/e/1FAIpQLSeSQJt-jQ9HETI8RGqxt7_XPhqNC8LTMsq3elkaLBnVg88OKA/viewform). 
 1. Create a copy of the [Maintainer Onboarding recruitment form](https://docs.google.com/forms/d/e/1FAIpQLSfXX8HWWltmDqw2T8GO4T7VV2OYG7PnVVEYHbEpS0MHA92Pyg/viewform) and adjust templated text as needed.  
-1. Creates a blog post to announce opening of applications. (Example [blog post](https://carpentries.org/blog/2021/06/maintainer_onboarding/).) Submit blog post text to the Communications Manager. 
+1. Create a blog post to announce opening of applications. (Example [blog post](https://carpentries.org/blog/2021/06/maintainer_onboarding/).) Submit blog post text to the Communications Manager. 
 1. Coordinate with Communications Manager about announcing on other channels (e.g. newsletter, Twitter). 
 1. Once the application period has closed, review applications and determine who to invite.
 1. Determine appropriate schedule for Maintainer Onboarding sessions based on responses to the scheduling poll included in the application. 

--- a/topic_folders/maintainers/maintainers.md
+++ b/topic_folders/maintainers/maintainers.md
@@ -74,23 +74,24 @@ the onboarding process.
 1. Coordinate with Communications Manager about announcing on other channels (e.g. newsletter, Twitter). 
 1. Once the application period has closed, review applications and determine who to invite.
 1. Determine appropriate schedule for Maintainer Onboarding sessions based on responses to the scheduling poll included in the application. 
-1. Send accepted applicants an [invitation](email_templates.html#inviting-new-maintainers) to become a Maintainer. Send non-selected applicants a [rejection email](email_templates.html#rejection).
+1. Send accepted applicants an [invitation](email_templates.html#inviting-new-maintainers) to become a Maintainer. Send non-selected applicants a [rejection email](email_templates.html#application-not-accepted).
 1. Create a private Slack channel (`Maintainer-Onboarding`) and invite trainees. 
 1. Populate the [Maintainer Onboarding Etherpad](https://pad.carpentries.org/maintainer-onboarding) with meeting dates and times. Use [timeanddate meeting time announcer](https://www.timeanddate.com/worldclock/fixedform.html) links to make it easy for people to convert meeting times to their own time zone.
 1. Create calendar invites with Zoom room and Etherpad link and send to trainees.
 1. Set up a [new event in AMY](https://carpentries.github.io/amy/users_guide/#adding-a-new-event) with the slug YEAR-MO-DA-maintainer-onboarding. Add trainees as learners. Add onboarding leader (Curriculum Team member and/or Maintainer Community Lead) as instructor.
+1. Decide on lesson assignments and send [lesson assignment email](email_templates.html#lesson-assignment).
 1. One week before the first onboarding meeting, send a reminder [email](email_templates.html#onboarding-reminder).
 1. Run onboarding according to [the curriculum](https://carpentries.github.io/maintainer-onboarding/). Keep record of who participates.
 
 After onboarding:
-1. Send [congratulations email](email_templates.html#congratulations) to new Maintainers.
+1. Send [congratulations email](email_templates.html#onboarding-complete) to new Maintainers.
 1. Add new Maintainer to the appropriate team for [Software Carpentry][SWC GH Lesson Maintainer Teams], [Data Carpentry][DC GH Lesson Maintainer Teams], [Library Carpentry][LC GH Lesson Maintainer Teams], or [The Carpentries][The Carpentries GH Lesson Maintainer Teams] Lesson Maintainers. This will give them write privileges for that lesson's repo.
 1. Add to lessons table on appropriate Lesson Program lesson page. 
 1. [Award them a Maintainer badge in AMY](https://carpentries.github.io/amy/users_guide/#issuing-badges). If the individual has [consented to having their profile published](https://carpentries.github.io/amy/users_guide/#adding-a-new-person), they will appear on [The Carpentries Maintainers page](https://carpentries.org/maintainers/) within a day.
 1. Add them to the "maintainers" channel in the Carpentries Slack.
 1. Add them to the ["maintainers" Topicbox email list](https://carpentries.topicbox.com/groups/maintainers).
-1. Send introductory emails for each new Maintainer(s) to the existing Maintainers for their lesson.
-1. Send [email](email_templates.html#welcoming-new-maintainers) to the Maintainers email list announcing new Maintainers.
+1. Send [introductory emails](email_templates.html#introduction-to-co-maintainers) for each new Maintainer(s) to the existing Maintainers for their lesson.
+1. Send [email](email_templates.html#general-introduction-on-maintainers-list) to the Maintainers email list announcing new Maintainers.
 1. Run sendmail_maintainer_certificates.R to send new Maintainers their certificates.
 1. Publish a blog post welcoming new Maintainers (example [blog post here](https://carpentries.org/blog/2020/07/maintainer-welcome-2020/). 
 1. Coordinate with the Communications Manager to announce new Maintainers in the next [newsletter](https://carpentries.org/newsletter/), on Twitter, and Slack general channel.

--- a/topic_folders/maintainers/maintainers.md
+++ b/topic_folders/maintainers/maintainers.md
@@ -3,7 +3,7 @@
 
 The Carpentries Maintainers work with the community to make sure that lessons stay up-to-date, accurate, functional and cohesive. They monitor
 their lesson repository, make sure that PRs and Issues are addressed in a timely manner, and participate in the lesson development cycle
-including lesson releases. They endeavour to be welcoming and supportive of contributions from all members of the community.
+including lesson releases. They endeavor to be welcoming and supportive of contributions from all members of the community.
 
 The division of responsibilities between Maintainers and Curriculum Advisors is detailed 
 in [this consultation rubric](https://docs.carpentries.org/topic_folders/lesson_development/cac-consult-rubric.html).
@@ -13,11 +13,11 @@ Maintainers are responsible for:
     - Ensuring reasonable response time to all submitted Issues and PRs. At a minimum, ensuring all Issues and PRs are acknowledged within two days.
     - Quickly addressing issues and PRs tagged as “bug”s.
     - Submitting Issues as they arise.
-    - Adhering to the Code of Conduct and alerting the Policy Subcommittee to any potential violations.
+    - Adhering to the Code of Conduct and alerting the Code of Conduct Committee to any potential violations.
     - Identifying potential new Maintainers based on their review activity.
 
-- Every six months:
-    - Participating in regular Issue Bonanza and Bug BBQ events, including organising and tagging issues.
+- Periodically:
+    - Helping prepare lessons for publication.
     - Bringing in updates to the lesson template.
 
 Maintainers represent The Carpentries community and should strive to embody The Carpentries philosophy, by:
@@ -30,13 +30,11 @@ Maintainers represent The Carpentries community and should strive to embody The 
     - Keep language motivating.
     - Emphasise the importance of continued learning and improvement.
 
-Note: These guidelines are adapted from those currently in use by the Data Carpentry Genomics Maintainers and are provisional. The Maintainer team will be deciding on official guidelines for the full set of Carpentries lesson Maintainers.
-
 ## How to Stay in Touch
 
 The overall Maintainer community communicates using our [mailing list](https://carpentries.topicbox.com/groups/maintainers) and our [Slack channel](https://swcarpentry.slack.com/messages/C8H5LN44V/details/). If you do not already have a Slack account with The Carpentries, you can [create one](https://swc-slack-invite.herokuapp.com/).
 
-The Maintainer community meets monthly to discuss issues relevant to all lesson Maintainers. Our meeting schedule can be found on [our Etherpad](https://codimd.carpentries.org/maintainers?both) and on the [community calendar](https://carpentries.org/community/#community-events).
+The Maintainer community meets monthly to discuss issues relevant to all lesson Maintainers. Our meeting schedule can be found on [our CodiMD](https://codimd.carpentries.org/maintainers?both) and on the [community calendar](https://carpentries.org/community/#community-events).
 
 Each Lesson Team also has their own Slack channel. A link to join your lesson's Slack channel can be found
 in the README file in your lesson repository.
@@ -49,48 +47,55 @@ in the README file in your lesson repository.
 
 There are many ways to request help on an issue or PR you are reviewing. To get help from other Maintainers or the general community, use the `help wanted` or `good first issue` labels. If your lesson is included on [the Help Wanted page of The Carpentries website](https://carpentries.org/help-wanted-issues/#for-maintainers), issues labelled `help wanted` will automatically be listed for potential contributors to find there.
 
-If an issue affects the overall structure or scope of the lesson, you can refer the issue to your curriculum's [Curriculum Advisory Subcommittee](../lesson_development/lesson_development_roles.html#curriculum-advisory-committee) by using the `status:refer-to-cac` label. Remember that the Curriculum Advisors only meet once every six months (in advance of lesson releases) and they will likely not be able to provide a quick response to your question.
+If an issue affects the overall structure or scope of the lesson, you can refer the issue to your curriculum's [Curriculum Advisory Subcommittee](../lesson_development/lesson_development_roles.html#curriculum-advisory-committee) by assigning it to the appropriate CAC GitHub team. Curriculum Advisors meet approximately quarterly.
 
 You can also get help from other Maintainers and interested community members by posting a question to your lesson's Slack channel.
 
-## How to Suggest Changes to the Styling for all Lessons
-
-Information coming soon.
-
 ## Maintainer Onboarding
 
+**The process for Maintainer Onboarding is currently on hold.  If you are interested in becoming a lesson Maintainer, please contact us at [team@carpentries.org](mailto:team@carpentries.org).**
 
-**The process for Maintainer onboarding is currently on hold.  If you are interested in becoming a lesson Maintainer, please contact us at [team@carpentries.org](mailto:team@carpentries.org).**
+New Maintainers go through an onboarding process, led by a member of The Carpentries Curriculum Team and the Maintainer Community Lead. Unless otherwise
+specified in the workflow below, the duties below are divided ad hoc between
+Curriculum Team member and Maintainer Community Lead. 
 
-New Maintainers go through an onboarding process. The curriculum for
+The curriculum for
 onboarding new Maintainers is available as a
 [Maintainer Onboarding Lesson](https://carpentries.github.io/maintainer-onboarding/).
 This documentation describes how to recruit new Maintainers and take them through
-the onboarding process.
+the onboarding process. 
 
-1. The application to become a Maintainer is [a Google form](https://docs.google.com/forms/d/e/1FAIpQLSfuSUffza_DrqqMwdokdNtSgNfdxzMSmbwLw8655GU31BXPyg/viewform?usp=sf_link). Please ensure that this collects the Github usernames of new Maintainers.
-1. Advertise for new Maintainers on the blog, mailing lists and Twitter.
-1. Once the application period has closed, reviewing applications and send accepted applicants an [invitation](email_templates.html#inviting-new-maintainers) to become a Maintainer.
-1. To set up a scheduling poll to schedule Maintainer Onboarding, use [WhenIsGood](http://whenisgood.net/). Click "Use Timezones" and then "SHOW OPTIONS". Unselect Sunday and Saturday. Add Duration = 60 minutes. Select "hide dates".
-1. Add Maintainers who are going through training to the [maintainer-onboarding Google Group](https://groups.google.com/a/carpentries.org/forum/#!forum/maintainer-onboarding). This is where announcements about upcoming meetings should be sent.
-1. After the deadline has passed for responding to the Maintainer Onboarding scheduling poll, select the two times that maximise attendance. This needs to be done manually from the whenisgood results, as there is not a "choose two times" option.
-1. Populate the [Maintainer onboarding Etherpad](https://pad.carpentries.org/maintainer-onboarding) with meeting dates and times. Use [timeanddate meeting time announcer](https://www.timeanddate.com/worldclock/fixedform.html) links to make it easy for people to convert meeting times to their own time zone.
-1. Send out an [email](email_templates.html#maintainer-onboarding-meetings) to the Google Group letting everyone know about the scheduling.
-1. Set up a [new event in AMY](https://carpentries.github.io/amy/users_guide/#adding-a-new-event) with the slug YEAR-MO-DA-maintainer-onboarding. Add all maintainer trainees as learners. Add onboarding leader as instructor.
-1. One week before the first onboarding meeting, send a reminder [email](email_templates.html#onboarding-reminder) to the Google Group.
-1. Run the three weeks of meetings according to [the curriculum](https://carpentries.github.io/maintainer-onboarding/). Keep record of who participates in the AMY event.
-1. If people are not able to make all of the meetings, [email](email_templates.html#missed-onboarding-meeting) them to ask them to write out responses to the discussion questions and homework.
+*Note to Core Team members:* the workflow detailed below is also available as a 
+[Asana project template](https://app.asana.com/0/1185099340351503/list). Once you've created your project, share it with the Maintainer Community Lead.  
 
-### Adding Maintainers to Carpentries systems
+1. Identify lessons in need of additional maintenance support. This includes surveying current Maintainers using [a Google form](https://docs.google.com/forms/d/e/1FAIpQLSeSQJt-jQ9HETI8RGqxt7_XPhqNC8LTMsq3elkaLBnVg88OKA/viewform). 
+1. Create a copy of the [Maintainer Onboarding recruitment form](https://docs.google.com/forms/d/e/1FAIpQLSfXX8HWWltmDqw2T8GO4T7VV2OYG7PnVVEYHbEpS0MHA92Pyg/viewform) and adjust templated text as needed.  
+1. Creates a blog post to announce opening of applications. (Example [blog post](https://carpentries.org/blog/2021/06/maintainer_onboarding/).) Submit blog post text to the Communications Manager. 
+1. Coordinate with Communications Manager about announcing on other channels (e.g. newsletter, Twitter). 
+1. Once the application period has closed, review applications and determine who to invite.
+1. Determine appropriate schedule for Maintainer Onboarding sessions based on responses to the scheduling poll included in the application. 
+1. Send accepted applicants an [invitation](email_templates.html#inviting-new-maintainers) to become a Maintainer. Send non-selected applicants a [rejection email](email_templates.html#rejection).
+1. Create a private Slack channel (`Maintainer-Onboarding`) and invite trainees. 
+1. Populate the [Maintainer Onboarding Etherpad](https://pad.carpentries.org/maintainer-onboarding) with meeting dates and times. Use [timeanddate meeting time announcer](https://www.timeanddate.com/worldclock/fixedform.html) links to make it easy for people to convert meeting times to their own time zone.
+1. Create calendar invites with Zoom room and Etherpad link and send to trainees.
+1. Set up a [new event in AMY](https://carpentries.github.io/amy/users_guide/#adding-a-new-event) with the slug YEAR-MO-DA-maintainer-onboarding. Add trainees as learners. Add onboarding leader (Curriculum Team member and/or Maintainer Community Lead) as instructor.
+1. One week before the first onboarding meeting, send a reminder [email](email_templates.html#onboarding-reminder).
+1. Run onboarding according to [the curriculum](https://carpentries.github.io/maintainer-onboarding/). Keep record of who participates.
 
-1. Do the following for each of the Maintainers who have completed the onboarding requirements:
-    - Add them to the appropriate team for [Software Carpentry][SWC GH Lesson Maintainer Teams], [Data Carpentry][DC GH Lesson Maintainer Teams], [Library Carpentry][LC GH Lesson Maintainer Teams], or [The Carpentries][The Carpentries GH Lesson Maintainer Teams] Lesson Maintainers. This will give them write privileges for that lesson's repo.
-    - [Award them a Maintainer badge in AMY](https://carpentries.github.io/amy/users_guide/#issuing-badges). If the individual has [consented to having their profile published](https://carpentries.github.io/amy/users_guide/#adding-a-new-person), they will appear on [The Carpentries Maintainers page](https://carpentries.org/maintainers/) within a day.
-    - Add them to the "maintainers" channel in the Carpentries Slack.
-    - Add them to the "maintainers" Topicbox email list.
+After onboarding:
+1. Send [congratulations email](email_templates.html#congratulations) to new Maintainers.
+1. Add new Maintainer to the appropriate team for [Software Carpentry][SWC GH Lesson Maintainer Teams], [Data Carpentry][DC GH Lesson Maintainer Teams], [Library Carpentry][LC GH Lesson Maintainer Teams], or [The Carpentries][The Carpentries GH Lesson Maintainer Teams] Lesson Maintainers. This will give them write privileges for that lesson's repo.
+1. Add to lessons table on appropriate Lesson Program lesson page. 
+1. [Award them a Maintainer badge in AMY](https://carpentries.github.io/amy/users_guide/#issuing-badges). If the individual has [consented to having their profile published](https://carpentries.github.io/amy/users_guide/#adding-a-new-person), they will appear on [The Carpentries Maintainers page](https://carpentries.org/maintainers/) within a day.
+1. Add them to the "maintainers" channel in the Carpentries Slack.
+1. Add them to the ["maintainers" Topicbox email list](https://carpentries.topicbox.com/groups/maintainers).
+1. Send introductory emails for each new Maintainer(s) to the existing Maintainers for their lesson.
 1. Send [email](email_templates.html#welcoming-new-maintainers) to the Maintainers email list announcing new Maintainers.
 1. Run sendmail_maintainer_certificates.R to send new Maintainers their certificates.
-1. Announce new Maintainers in the next [newsletter](https://carpentries.org/newsletter/).
+1. Publish a blog post welcoming new Maintainers (example [blog post here](https://carpentries.org/blog/2020/07/maintainer-welcome-2020/). 
+1. Coordinate with the Communications Manager to announce new Maintainers in the next [newsletter](https://carpentries.org/newsletter/), on Twitter, and Slack general channel.
+1. Clear member list on the `Maintainer-Onboarding` TopicBox.
+1. Archive the Asana project. 
 
 
 [SWC GH Lesson Maintainer Teams]: https://github.com/orgs/swcarpentry/teams/lesson-maintainers

--- a/topic_folders/maintainers/maintainers.md
+++ b/topic_folders/maintainers/maintainers.md
@@ -3,7 +3,7 @@
 
 The Carpentries Maintainers work with the community to make sure that lessons stay up-to-date, accurate, functional and cohesive. They monitor
 their lesson repository, make sure that PRs and Issues are addressed in a timely manner, and participate in the lesson development cycle
-including lesson releases. They endeavor to be welcoming and supportive of contributions from all members of the community.
+including lesson releases. They endeavour to be welcoming and supportive of contributions from all members of the community.
 
 The division of responsibilities between Maintainers and Curriculum Advisors is detailed 
 in [this consultation rubric](https://docs.carpentries.org/topic_folders/lesson_development/cac-consult-rubric.html).
@@ -65,7 +65,7 @@ onboarding new Maintainers is available as a
 This documentation describes how to recruit new Maintainers and take them through
 the onboarding process. 
 
-*Note to Core Team members:* the workflow detailed below is also available as a 
+*Note to Core Team members:* the workflow below is also available as a 
 [Asana project template](https://app.asana.com/0/1185099340351503/list). Once you've created your project, share it with the Maintainer Community Lead.  
 
 1. Identify lessons in need of additional maintenance support. This includes surveying current Maintainers using [a Google form](https://docs.google.com/forms/d/e/1FAIpQLSeSQJt-jQ9HETI8RGqxt7_XPhqNC8LTMsq3elkaLBnVg88OKA/viewform). 

--- a/topic_folders/maintainers/maintainers.md
+++ b/topic_folders/maintainers/maintainers.md
@@ -86,7 +86,7 @@ the onboarding process.
 After onboarding:
 1. Send [congratulations email](email_templates.html#onboarding-complete) to new Maintainers.
 1. Add new Maintainer to the appropriate team for [Software Carpentry][SWC GH Lesson Maintainer Teams], [Data Carpentry][DC GH Lesson Maintainer Teams], [Library Carpentry][LC GH Lesson Maintainer Teams], or [The Carpentries][The Carpentries GH Lesson Maintainer Teams] Lesson Maintainers. This will give them write privileges for that lesson's repo.
-1. Add to lessons table on appropriate Lesson Program lesson page. 
+1. Add to lessons table on appropriate Lesson Program lesson page (e.g. <https://datacarpentry.org/lessons>). 
 1. [Award them a Maintainer badge in AMY](https://carpentries.github.io/amy/users_guide/#issuing-badges). If the individual has [consented to having their profile published](https://carpentries.github.io/amy/users_guide/#adding-a-new-person), they will appear on [The Carpentries Maintainers page](https://carpentries.org/maintainers/) within a day.
 1. Add them to the "maintainers" channel in the Carpentries Slack.
 1. Add them to the ["maintainers" Topicbox email list](https://carpentries.topicbox.com/groups/maintainers).


### PR DESCRIPTION
At LOOOOONG last, I'm finally getting around to updating the documentation for Maintainer Onboarding in our Handbook. @tobyhodges if you could review this from a content perspective at some point in the next month or so, that would be wonderful. @maneesha can then review to make sure the formatting is on par for the Handbook and merge. Thank you both! 