### PR TITLE
Remove links to outdated pages

### DIFF
--- a/topic_folders/lesson_development/curriculum_advisory_committees.md
+++ b/topic_folders/lesson_development/curriculum_advisory_committees.md
@@ -65,7 +65,5 @@ To be added.
 
 ### Current Curriculum Advisors
 
-* [Curriculum Advisors, Data Carpentry](https://datacarpentry.org/lesson-leadership/)
-* [Curriculum Advisors, Library Carpentry](https://librarycarpentry.org/cac/)
-* [Curriculum Advisors, Software Carpentry](https://software-carpentry.org/curriculum-advisors/)
+Refer to [The Carpentries Curriculum Advisors page](https://carpentries.org/curriculum-advisors/) for a current list of Curriculum Advisors and contact information.
 


### PR DESCRIPTION
The handbook currently links to the individual lesson program webpages for lists of CACs. This replaces that reference with a link to the page on The Carpentries website. After we have built committee member pages using the new community roles feature in AMY, can change this back to direct to individual lesson program webpages. 