### PR TITLE
Update markdown parser to MyST

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -39,6 +39,9 @@ extensions = ['notfound.extension',
               'myst_parser', # Enable use of markdown
               ]
 
+# give auto anchors to myst docs
+myst_heading_anchors = 6
+
 notfound_context = {
         'body': '<h1>This page may have moved.</h1> <p>Please select a page from the side menu or contact team@carpentries.org if you need additional help.</p>',
 }

--- a/conf.py
+++ b/conf.py
@@ -35,9 +35,8 @@ needs_sphinx = '1.8'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx_markdown_tables',
-              'notfound.extension',
-              'recommonmark', # Enable use of markdown
+extensions = ['notfound.extension',
+              'myst_parser', # Enable use of markdown
               ]
 
 notfound_context = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-recommonmark>=0.5.0
 Sphinx>=1.8
 sphinx_rtd_theme>=0.4.2
-sphinx-markdown-tables>=0.0.9
 sphinx-notfound-page==0.3
+myst-parser>=0.17.2


### PR DESCRIPTION
I've changed the parser to MyST. 

MyST yelled at me about some missing anchors, but when I looked, it seems like those anchors truly don't exist, so I think it's doing its job.

This will fix #835 