### PR TITLE
IDC -> Trainers Leadership

### DIFF
--- a/topic_folders/governance/lesson-program-policy.md
+++ b/topic_folders/governance/lesson-program-policy.md
@@ -19,7 +19,7 @@ This page contains:
 
 ### Lesson Program Governance Policy
 
-Note that [Instructor Training Governance](https://docs.carpentries.org/topic_folders/instructor_development/instructor_development_committee.html) will also follow this policy.
+Note that the [Trainers Leadership Committee](https://github.com/carpentries/trainers/blob/main/governance.md) will also follow this policy.
 
 * Each Lesson Program will have a Lesson Program Governance Committee.
 * Each Lesson Program Governance Committee will comply with the general [committee policy as described in the Carpentries Handbook](https://docs.carpentries.org/topic_folders/governance/committee-policy.html)


### PR DESCRIPTION
Based on conversations between EC and Trainers Leadership on this subject, I'm quite certain that they meant to refer to the Trainers Leadership Committee, not the Instructor Development Committee (which is what is linked from "Instructor Training Governance"). 

I am submitting this as a PR to make it as easy as possible, but I also recognize that this may be text that can only be updated by the EC. Let me know if I should do anything in addition to submitting this PR here.

