### PR TITLE
add background to high luminance brand-identity colours

### DIFF
--- a/topic_folders/communications/resources/brand_identity.md
+++ b/topic_folders/communications/resources/brand_identity.md
@@ -10,31 +10,42 @@
 
 <p style="color:#FF4955;"><span style="font-size:50px;">&#9733;</span>Fire:  #FF4955 or rgb(255, 73, 85).</p>
 
+<div style="background-color:#383838; margin-top: -15px; padding-top: 15px">
 <p style="color:#FFC700;"><span style="font-size:50px;">&#9733;</span>Golden: #FFC700 or rgb(255, 199, 0).</p>
-
 <p style="color:#FFF7F1;"><span style="font-size:50px;">&#9733;</span>Buttercup: #FFF7F1 or rgb(255, 247, 241).</p>
+</div>
 
 ### Lesson Program Colours and Shades
+
 <p style="color:#081457;"><span style="font-size:50px;">&#9733;</span>General Carpentries: #081457 or rgb(8, 20, 87).</p>
 
+<div style="background-color:#383838; margin-top: -15px; padding-top: 15px">
 <p style="color:#E3E6FC;"><span style="font-size:50px;">&#9733;</span>General Carpentries (Light): #E3E6FC or rgb(227, 230, 252).</p>
+</div>
 
 <p style="color:#205959;"><span style="font-size:50px;">&#9733;</span>Data Carpentries: #205959 or rgb(32, 89, 89).</p>
 
+<div style="background-color:#383838; margin-top: -15px; padding-top: 15px">
 <p style="color:#40AEAD;"><span style="font-size:50px;">&#9733;</span>Data Carpentries (Light): #40AEAD or rgb(64, 174, 173).</p>
+</div>
 
 <p style="color:#201434;"><span style="font-size:50px;">&#9733;</span>Software Carpentries: #201434 or rgb(32, 20, 52).</p>
 
+<div style="background-color:#383838; margin-top: -15px; padding-top: 15px">
 <p style="color:#D2BDF2;"><span style="font-size:50px;">&#9733;</span>Software Carpentries (Light): #D2BDF2 or rgb(210, 189, 242).</p>
+</div>
 
 <p style="color:#A4050E;"><span style="font-size:50px;">&#9733;</span>Library Carpentries: #A4050E or rgb(164, 5, 14).</p>
 
+<div style="background-color:#383838; margin-top: -15px; padding-top: 15px">
 <p style="color:#F99697;"><span style="font-size:50px;">&#9733;</span>Library Carpentries (Light): #F99697 or rgb(249, 150, 151).</p>
+</div>
 
 ### Secondary/Supplementary Colours and Shades
 
 <p style="color:#0044d7;"><span style="font-size:50px;">&#9733;</span>Lake: #0044d7 or rgb(0, 68, 215).</p>
 
+<div style="background-color:#383838; margin-top: -15px; padding-top: 15px">
 <p style="color:#719eff;"><span style="font-size:50px;">&#9733;</span>Pond: #719eff or rgb(113, 158, 255).</p>
 
 <p style="color:#E6F1FF;"><span style="font-size:50px;">&#9733;</span>Sky: #E6F1FF or rgb(230, 241, 255).</p>
@@ -50,6 +61,7 @@
 <p style="color:#FFD6D8;"><span style="font-size:50px;">&#9733;</span>Dawn: #FFD6D8 or rgb(255, 214, 216).</p>
 
 <p style="color:#FFE7A8;"><span style="font-size:50px;">&#9733;</span>Dawn: #FFE7A8 or rgb(255, 231, 168).</p>
+</div>
 
 
 ## Carpentries Fonts


### PR DESCRIPTION
I added the carpentries black background to the colours on the brand identity page. To be honest, I didn't even realise that "buttercup" was one of the main brand colours!

Here are some screenshots:

![main brand identity colours](https://user-images.githubusercontent.com/3639446/168701037-24f9eb39-9e55-48a3-bb37-ead073bd57b3.png)

![lesson program colours](https://user-images.githubusercontent.com/3639446/168701081-400e3ec4-a449-423b-9f0b-5539a81d6770.png)

![secondary colours](https://user-images.githubusercontent.com/3639446/168701122-f3c47077-62f8-4076-bdcb-2db681f8c02c.png)

This will fix #840


