### PR TITLE
Remove "and Instructors"

### DIFF
--- a/topic_folders/governance/bylaws.md
+++ b/topic_folders/governance/bylaws.md
@@ -20,7 +20,7 @@ The Executive Council is responsible for assessing a prospective Lesson Program 
 A Lesson Program within The Carpentries should possess the following characteristics:
 - Intention and purpose for lessons that align with The Carpentries mission and vision
 - Goals and objectives for lessons and/or workshops that are distinct from other Lesson Programs
-- Service to a particular audience of learners and instructors
+- Service to a particular audience of learners
 - Evidence of community member commitment to Lesson Program governance (see below), lesson maintenance, and curriculum development
 
 ### Governance of Lesson Programs

--- a/topic_folders/governance/lesson-program-policy.md
+++ b/topic_folders/governance/lesson-program-policy.md
@@ -6,7 +6,7 @@ From [The Carpentries Bylaws](https://docs.carpentries.org/topic_folders/governa
 *A Lesson Program within The Carpentries possesses the following characteristics:  
 - Intention and purpose for lessons that align with The Carpentries mission and vision
 - Goals and objectives for lessons and/or workshops that are distinct from other Lesson Programs
-- Service to a particular audience of learners and instructors
+- Service to a particular audience of learners
 - Evidence of community member commitment to Lesson Program governance (see below), lesson maintenance, and curriculum development*
 
 Adoption as an official The Carpentries Lesson Program is the last step of Lesson Program incubation as outlined in the [Lesson Program Incubation Roadmap](#lesson-program-incubation-roadmap).


### PR DESCRIPTION
Suggestion to change the verbiage to "Service to a particular audience of learners" by removing "and Instructors." We want all Instructors to be able to teach all lesson programs.

