### PR TITLE
Update certification renewal to reflect roles vs badges

### DIFF
--- a/topic_folders/fundraising/collaborating-on-grants.md
+++ b/topic_folders/fundraising/collaborating-on-grants.md
@@ -34,7 +34,7 @@ For more information about grants we have received from these sources, please re
 ### Sponsors
 - [Biotech Partners](http://www.biotechpartners.org/)
 - [Jump Recruits, LLC](https://jumprecruits.com/)
-- [RStudio](https://rstudio.com/)
+- [Posit](https://rstudio.com/)
 
 For more information about sponsorship opportunities, visit our [Sponsorship Program page](https://carpentries.org/sponsorship/).
 

--- a/topic_folders/instructor_training/duties_agreement.md
+++ b/topic_folders/instructor_training/duties_agreement.md
@@ -14,7 +14,7 @@ community, through leadership roles. Trainers often play leadership roles in the
 
 ##### Active Status Renewal Process
 
-Version 1.0.1 -- Draft
+Version 1.0.1 -- Approved 8 February, 2023
 
 Active status for Instructor Trainers is renewed annually in March. 
 


### PR DESCRIPTION
The guiding purpose of this update is to align this process with changes in the way AMY, The Carpentries database, handles status with regard to certification. The addition of "roles" makes it possible for us to change status from Active to Alumni *without removing or altering a badge.* Rather than renewing certification, this process now reflects a renewal of Active status, retaining permanent certification.

Additional language changes improve clarity and accuracy with regard to process implementation. 

There are NO changes to the requirements or necessary actions for Trainers.

This requires ratification by the Trainer community and should not be merged until that process is complete.