### PR TITLE
fix instructor training links

### DIFF
--- a/topic_folders/instructor_training/members_join.md
+++ b/topic_folders/instructor_training/members_join.md
@@ -8,7 +8,7 @@ We are excited to announce that [ site name ] has become a member of The Carpent
 
 [The Carpentries](https://carpentries.org) is a global community of volunteers who develop and teach interactive, hands-on workshops on computing and data skills, addressing basic training needs that are unmet in most disciplines.
 
-As part of our Carpentries membership, we can have [ number ] people from [ site name ] complete [The Carpentries’ Instructor Training program](https://carpentries.github.io/instructor.training/) and become certified Carpentries Instructors. 
+As part of our Carpentries membership, we can have [ number ] people from [ site name ] complete [The Carpentries’ Instructor Training program](https://carpentries.github.io/instructor-training/) and become certified Carpentries Instructors. 
 
 Certified Instructors can co-teach [Carpentries workshops](https://carpentries.org/workshops/) here at [ site name ], helping us reach more people and build these skills across our community. In addition, Carpentries Instructors also have the opportunity to teach as part of a team at other institutions in The Carpentries network, meeting others with similar skills who enjoy sharing them. Hosting institutions cover travel and expenses for volunteer Instructors teaching workshops in-person.
 
@@ -33,7 +33,7 @@ Instructor Training events are held online via video conference, with schedule o
 1. Visit the [Instructor Training Calendar](https://carpentries.github.io/instructor-training/training_calendar.html) and select an event. Click on the link to Eventbrite and use the following code: [ CODE ]. Please do not share this code.
 2. Complete The Carpentries’ [profile-creation form](https://amy.carpentries.org/forms/request_training/) using the same registration code: [ CODE ]. This allows The Carpentries to track your progress to certification. 
 
-You will receive more details about your training from The Carpentries (instructor.training@carpentries.org) one week prior to your event. Be sure to look out for this email, and check your spam filters. There is a small amount of preparation expected before the training as well as three short tasks involved in certification. To learn more, see the [Preparing for Training and Certification page](https://carpentries.github.io/instructor-training/setup.html). 
+You will receive more details about your training from The Carpentries (instructor.training@carpentries.org) one week prior to your event. Be sure to look out for this email, and check your spam filters. There is a small amount of preparation expected before the training as well as three short tasks involved in certification. To learn more, see the [Preparing for Training and Certification page](https://carpentries.github.io/instructor-training/#setup). 
 
 If anything comes up and you are no longer interested or able to participate, please let me know as soon as possible so that I can offer this seat to another person.
 


### PR DESCRIPTION
There were some broken links in the template email