### PR TITLE
Standardize the use of CoC committee

### DIFF
--- a/topic_folders/policies/incident-response.md
+++ b/topic_folders/policies/incident-response.md
@@ -2,14 +2,14 @@
 
 Information on how to report a Code of Conduct (CoC) incident is outlined in our [Code of Conduct Incident Reporting Guidelines](incident-reporting.md).
 
-The checklists below outline the steps any community member (workshop host, [instructor](https://carpentries.org/instructors/), helper, etc.) can take during a potential Code of Conduct incident __before__ reporting it to the Code of Conduct Committee. You may encounter challenging situations and have limited experience or training to feel comfortable enforcing the CoC. These guidelines are meant to help guide you through the process of supporting other community members and yourself during an incident. 
+The checklists below outline the steps any community member (workshop host, [instructor](https://carpentries.org/instructors/), helper, etc.) can take during a potential Code of Conduct incident __before__ reporting it to the Code of Conduct committee (CoCc). You may encounter challenging situations and have limited experience or training to feel comfortable enforcing the CoC. These guidelines are meant to help guide you through the process of supporting other community members and yourself during an incident. 
 
 All Carpentries community members should feel empowered to enforce the Code of Conduct. 
 
 Ideally, we would all be able to defuse an incident. In practice, we have varying comfort with situations depending on our current experience and the environment. Below are ways that you can be supportive and steps that you can take during or after an incident.
 
-If you can, move from being a bystander to being a Code of Conduct first responder. If you see something inappropriate happening, speak up. If you don't feel comfortable intervening, but feel someone should, please submit a report via the [Code of Conduct incident report form][reporting-form] to the Code of Conduct committee.
-For in person events, please immediately contact a workshop host or instructor so that they can assist you in implementing the **Immediate Response Checklist** as listed below, and help submit a report to the Code of Conduct committee.
+If you can, move from being a bystander to being a Code of Conduct first responder. If you see something inappropriate happening, speak up. If you don't feel comfortable intervening, but feel someone should, please submit a report via the [Code of Conduct incident report form][reporting-form] to the CoCc.
+For in person events, please immediately contact a workshop host or instructor so that they can assist you in implementing the **Immediate Response Checklist** as listed below, and help submit a report to the CoCc.
 
 ##### Immediate Response 
 
@@ -17,7 +17,7 @@ The initial response to an incident is very important and will set the tone for 
 
 ##### Ongoing Incidents
 
-If an incident is ongoing, whether in-person or online, any community member (workshop host, instructor, helper) may act immediately and employ any of the tools available to the community member to pacify the situation. In situations where an individual community member acts immediately, they must inform the workshop host as soon as possible and report their actions to the Code of Conduct Committee for review within 24 hours of the incident. Should there be a need for an immediate response, please see the [Immediate Response Checklist](#checklists-for-responding-to-an-incident).
+If an incident is ongoing, whether in-person or online, any community member (workshop host, instructor, helper) may act immediately and employ any of the tools available to the community member to pacify the situation. In situations where an individual community member acts immediately, they must inform the workshop host as soon as possible and report their actions to the CoCc for review within 24 hours of the incident. Should there be a need for an immediate response, please see the [Immediate Response Checklist](#checklists-for-responding-to-an-incident).
 
 ##### Checklists for Responding to an Incident
 
@@ -32,14 +32,14 @@ If an incident is ongoing, whether in-person or online, any community member (wo
 * If participants are not safe, refer to the [Immediate Response Checklist](#checklists-for-responding-to-an-incident).
 * Ask the reporter to report the incident via the [Code of Conduct Incident Report Form][reporting-form]. 
 * If they would like your help or feel more comfortable if you complete the report, talk to them or communicate via email/online call to get their inputs in getting as much detail as possible, and help submit the report with their assistance. 
-* Inform the workshop host or the listed contact person (such as a CoC facilitator) that there was an incident and that a report was submitted via the [incident report form][reporting-form]. If the incident involves the workshop host or instructor, report the incident directly to the Code of Conduct committee via the incident report form. 
+* Inform the workshop host or the listed contact person (such as a CoC facilitator) that there was an incident and that a report was submitted via the [incident report form][reporting-form]. If the incident involves the workshop host or instructor, report the incident directly to the CoCc via the incident report form. 
 
 **Online Communications Channels Checklist (Teaching Demonstrations, Community Discussions, Carpentries Instructor Training, Slack Channels, TopicBox)**
 * Inform the event host/meeting facilitator that there was an issue and send a report via the [incident report form][reporting-form].
 * Save screenshot of any online interaction where the issue occured and share in your report.
 * If the incident involves the event host/meeting facilitator, please complete the [incident report form][reporting-form] and rest assured that confidentiality and your experience in our community is our first priority.
 
-If a community member has violated the CoC via an online event, the CoC committee can enact a short-term [Termed Suspension](termed-suspension.md), and the reportee’s privileges to all Carpentries communication channels could be suspended until the Code of Conduct Committee has concluded their investigation of the reported incident.
+If a community member has violated the CoC via an online event, the CoCc can enact a short-term [Termed Suspension](termed-suspension.md), and the reportee’s privileges to all Carpentries communication channels could be suspended until the CoCc has concluded their investigation of the reported incident.
 
 Individuals reported often get upset, defensive, or deny the report. Allow them to give any additional details about the incident. However, remember:
 


### PR DESCRIPTION
The incident response page has a variety of usages for CoCc as CoC committee, Code of Conduct committee and Code of Conduct Committee. This commit standardizes them throughout the document.