### PR TITLE
Add handbook for LPGC members

### DIFF
--- a/topic_folders/governance/index.rst
+++ b/topic_folders/governance/index.rst
@@ -9,5 +9,6 @@ GOVERNANCE
    executive-council.md
    committee-policy.md
    task-force-policy.md
-   lesson-program-policy.md 
+   lesson-program-policy.md
+   lesson-program-governors.md
 

--- a/topic_folders/governance/lesson-program-governors.md
+++ b/topic_folders/governance/lesson-program-governors.md
@@ -1,0 +1,148 @@
+## Lesson Program Governor Handbook
+
+### Description of Community Role
+Lesson Program Governors are members of **Lesson Program Governance Committees (LPGCs)**, groups of community members that oversee and guide the strategy and health of The Carpentries Lesson Programs.
+
+The responsibilities of Lesson Program Governance Committees fall into three main categories of leadership: strategy, advocacy, and communication.
+* Strategy:
+  * Monitoring the health of the lesson program and designing strategies to maintain and improve it
+  * Identifying priorities for growing the community and reach of the lesson program
+* Advocacy:
+  * Representing the lesson program in their local and professional networks
+  * Working with the Executive Council and Core Team to promote the interests of the lesson program within The Carpentries
+* Communication:
+  * Reporting on the activities, objectives, and needs of the lesson program to the Executive Council and Core Team
+  * Engaging the community on topics and projects relevant to the development of the lesson program
+  * Maintaining up-to-date information about the lesson program on The Carpentries websites
+
+A Lesson Program Governance Committee will typically have 3-5 members, including at least one member acting in each of the two Officer roles, Chair and Secretary.
+
+#### Member Roles and responsibilities
+##### Chair
+* Prepare agenda for regular meetings, including time estimates for each item.
+* Set the agenda and send it out along with any other relevant documents to committee members at least one week in advance of meeting.
+* Assign meeting roles.
+* Serve as primary point of contact for the Executive Council, Core Team members, and Curriculum Advisors for the relevant lesson program.
+* Prepare a written update, twice per year, for the Executive Council, summarising the committee’s activities, main points and outcomes of discussion, and any major decisions made.
+* Communicate with the lesson program community and the Core Team, through GitHub issues, blog posts, or another appropriate platform, about decisions made by the LPGC.
+* Coordinate with Curriculum Team Lead (Toby Hodges) to request information and support from the Core Team to help the LPGC perform its functions, e.g. data and information relating to the health of the lesson program, or delegate responsibility for this to another committee member.
+* Notify Curriculum Team Lead if a LPGC member needs to step down mid-term or becomes unresponsive to communications, so that Core Team can help recruit a replacement if needed.
+* Approve meeting minutes.
+* Fulfil all other responsibilities of a LPGC member.
+
+##### Secretary
+* Schedule regular meetings.
+* Arrange meeting room logistics.
+* Send calendar invites.
+* Send meeting reminders.
+* Prepare meeting minutes and post to the appropriate LPGC GitHub repository.
+* Fulfil all other responsibilities of a LPGC member.
+
+##### Other members
+* Notify Chair of potential agenda items as they arise.
+* Review agenda and other relevant documents sent by Chair prior to meeting.
+* Attend and actively participate in regular meetings by being attentive, sharing knowledge, expertise, ideas, and information.
+* Participate in asynchronous voting through GitHub as needed.
+* Work with community members and Core Team to implement voted upon changes as needed.
+* (Optional) Be involved in discussions relevant to the LPGC on GitHub and elsewhere.
+
+#### Onboarding
+_Details of frequency and format of future Lesson Program Governor selections coming soon..._
+
+* Rounds of recruitment will be announced on The Carpentries blog.
+* Onboarding aims to provide new Lesson Program Governors with context for the role and how LPGCs fit into The Carpentries model for community governance, and what they can expect as they prepare to join their first committee meeting.
+* The first onboarding for Lesson Program Governors took place in three parts:
+  * A general onboarding for all Lesson Program Governors
+  * An optional but recommended session on _How to Run a Meeting_, led by Greg Wilson
+  * An additional onboarding for the committee officers (Roles and responsibilities above)
+* Onboardings are delivered by the Curriculum Team over Zoom, with the possibility to be onboarded through a recording of the sessions available for those who cannot attend synchronously.
+  * Links to onboarding slides are provided in [the Resources section](#resources).
+* After these onboarding sessions, Lesson Program Governors should complete the following steps:
+  * [Log into AMY](https://amy.carpentries.org/) with GitHub credentials and update their profile.
+  * When updating their AMY profile, it is essential that Governors give consent for The Carpentries to publish their profile so that they can be listed on The Carpentries websites.
+  * Join the mailing list for their committee on [The Carpentries TopicBox](https://carpentries.topicbox.com/groups).
+* Subscribe to notifications from the GitHub repository for their committee
+  * Repositories for each committee are listed in [the Communication and Collaboration Spaces section](#communication-and-collaboration-spaces).
+
+#### Term Length
+Term lengths for Lesson Program Governors are defined in the charter document of each individual committee. The committee charter can be found in the committee’s GitHub repository.
+
+#### Offboarding
+Offboarding is necessary when a Lesson Program Governor’s term ends or if they choose to step away from the role for any other reason. If a Governor wishes to leave their role outside the standard term limit, they should [notify the Curriculum Team](mailto:curriculum@carpentries.org).
+
+Lesson Program Governor offboarding includes the following steps, which will be coordinated by the Curriculum Team:
+
+* Reassigning any open issues on the committee repository to another committee member
+* Revoking their access to the GitHub repository
+* Removing them from the TopicBox group for the committee
+* Removing them from the LPGC listing on the lesson program and Carpentries websites
+* Inviting feedback from the departing member on their experience as an LPGC member
+
+### Communication and Collaboration Spaces
+#### Etherpad
+Below is a list of Etherpads relevant to serving as a Lesson Program Governor. 
+
+* [Pad-of-pads](https://pad.carpentries.org/pad-of-pads): A list of our most commonly used Etherpads and other resources.
+* [Community discussions](https://pad.carpentries.org/community-discussions): an etherpad for signing up to upcoming discussion events. If the LPGC schedules any discussions e.g. to consult with the lesson program community on a topic, these events will be listed here.
+
+#### GitHub
+The following LPGC repositories exist on GitHub, for collecting meeting minutes, managing discussion issues, etc:
+
+* Data Carpentry: <https://github.com/datacarpentry/governance>
+* Library Carpentry: <https://github.com/LibraryCarpentry/governance>
+* Software Carpentry: <https://github.com/swcarpentry/governance>
+
+#### Slack
+[To join The Carpentries Slack workspace, you can follow this link](https://swc-slack-invite.herokuapp.com/). 
+Although decision-making should be done in meetings and/or publicly-visible communication channels, LPGCs may also wish to create a private channel on this Slack workspace for day-to-day discussions, meeting planning, etc.
+If you are new to Slack, please check out our [Slack Quick Start Guide](https://docs.carpentries.org/topic_folders/communications/tools/slack-and-email.html#slack-quick-start-guide).
+
+#### TopicBox
+You can access The Carpentries mailing lists from [TopicBox](https://carpentries.topicbox.com/latest). Each LPGC has a dedicated mailing list on TopicBox:
+
+* Data Carpentry: <https://carpentries.topicbox.com/groups/dc-governors>
+* Library Carpentry: <https://carpentries.topicbox.com/groups/lc-governors>
+* Software Carpentry: <https://carpentries.topicbox.com/groups/swc-governors>
+
+These mailing lists are configured so that anyone can send a message to them, but list membership is moderated so that only current members of the committee will receive messages sent to the group.
+
+To join one or more Carpentries mailing lists, you will need to [create a login on the site](https://carpentries.topicbox.com/latest). Once you have done this, you can scroll through the list of groups and click “Join the Conversation” (for open mailing) or “Request to Join” (for those mailing lists requiring administrator approval). 
+
+### Step-by-Step Guides
+#### Writing a blog post
+Blog posts are a good way to publicise information to the community and call for contributions/feedback. Posts can be published to The Carpentries website by submitting a Markdown source file to [the carpentries/carpentries.org GitHub repository](https://github.com/carpentries/carpentries.org) via pull request. Blog post templates (as [a GoogleDoc template]() and [a CodiMD template]()) are provided to help you get started.
+
+1. Blog post source files should be placed in the `_posts` directory of the website source repository, in the appropriate folder by year and month of publication. The following rules must be followed for a post to display on the blog:
+2. The source file name must follow the structure YYYY-MM-DD-blog-post-title.md: the date string and .md file extension are essential for the post to be built and included in the blog listing.
+3. The first line of the post source file must be `---`
+4. The YAML header (between two `---` lines) must be present
+5. A blank line must be present between the closing `---` of the YAML header and the beginning of the post content
+
+The Curriculum Team can help LPGCs draft and publish blog posts.
+
+### Resources
+#### [Lesson Program Governor Onboarding Presentation](https://docs.google.com/presentation/d/1oDanpPZfEYgdg5yk0kKPMkFyBQ4nQN2ZyLru2SPIlBo/edit?usp=sharing)
+##### About this resource
+The slide deck for LPGC Onboarding in March and April 2023. This was a general onboarding session for all incoming Governance Committee members, providing information on The Carpentries, the history and structure of lesson program governance, the powers and responsibilities of LPGCs, and some of the logistics of committee operations.
+
+#### [LPGC Officer Onboarding Presentation](https://docs.google.com/presentation/d/1Fd6aANyU3mh_RbIBh9t2G5GR7DKVEfSXBrgVqos9-_E/edit?usp=sharing)
+##### About this resource
+The slide deck for onboarding LPGC Officers (chairs and secretaries) in March and April 2023. This session looked in more detail at these officer roles and the responsibilities that come with them, as well as discussing some of the logistics of organising and running committee meetings and some first steps officers could take to get started with their committees.
+
+#### [How to Run a Meeting Presentation](https://docs.google.com/presentation/d/1HSdgVQjq0d3UYh-aA4uWHXxYYpySn_xXwfn_M4Ms8Ts/edit?usp=sharing)
+##### About this resource
+The slide deck from Greg Wilson’s How to Run a Meeting session delivered to incoming LPGC members as part of onboarding in March and April 2023. This session provided some advice and guidance to follow to help ensure that time spent in committee meetings is used as effectively as possible.
+
+#### [Lesson Program Governance Policy](https://docs.carpentries.org/topic_folders/governance/lesson-program-policy.html#lesson-program-governance-policy)
+##### About this resource
+Official policy from The Carpentries Executive Council describing how individual lesson programs should be governed and listing the powers and responsibilities of LPGCs
+
+#### [Committee Policy](https://docs.carpentries.org/topic_folders/governance/committee-policy.html)
+##### About this resource
+The Carpentries general policy for committees, provided by the Executive Council. This policy describes in general terms the responsibilities and requirements of an official committee such as an LPGC within the organisation.
+
+### About This Section
+This section of the handbook is designed to support members of Lesson Program Governance Committees within The Carpentries community. It is maintained by The Carpentries Curriculum Team. If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please send an message to the team at <curriculum@carpentries.org>, or open an issue on [the source repository of this handbook](https://github.com/carpentries/docs.carpentries.org).
+
+
+


### PR DESCRIPTION
This adds a new section to the handbook, providing information for Lesson Program Governance Committee members.

I opted to place this in the _Governance_ section, but I acknowledge that this is not a perfect fit - it seemed like the "least worst" option of the different sections available. Please let me know if you suggest a different location, or if you would prefer that I create a whole new topic folder for this content.