### PR TITLE
Use current repository and branch names in Sphinx configuration

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -150,8 +150,8 @@ html_sidebars = {
 html_context = {
   'display_github': True,
   'github_user': 'carpentries',
-  'github_repo': 'handbook',
-  'github_version': 'master/',
+  'github_repo': 'docs.carpentries.org',
+  'github_version': 'main/',
   'theme_vcs_pageview_mode': 'blob'
 }
 


### PR DESCRIPTION
On every page in [The Carpentries Handbook], the *Edit on GitHub* link points to a previous repository name (*handbook*) and branch name (*master*). When I follow the link, I do get to the correct file in the repository, because GitHub redirects correctly, but it takes some time and I see *Branch not found, redirected to default branch.* at the top of the page.

This PR updates the Sphinx configuration to use `docs.carpentries.org` and `main`, respectively, to fix the above mentioned issues.