### PR TITLE
Update link to contribution guide

### DIFF
--- a/topic_folders/maintainers/contributing.md
+++ b/topic_folders/maintainers/contributing.md
@@ -1,3 +1,12 @@
 ## Contributing to Carpentries Lessons
 
-Lesson Maintainers actively maintain all Carpentries lessons. However, contributions are always welcome by all community members. Novice contributors can read [this guide](https://github.com/dmgt/swc_github_flow/blob/master/for_novice_contributors.md#) developed by Carpentries Instructors.  It provides instructions for contributing to The Carpentries' lesson materials using graphical or command line interfaces with Git and GitHub. The [Help Wanted page](https://carpentries.org/help-wanted-issues) lists issues in need of attention and is a good place to find out where your contributions are most needed.
+Lesson Maintainers actively maintain all Carpentries lessons.
+However, contributions are always welcome by all community members.
+Novice contributors can read the [Instructions for contributing to The Carpentries' lesson materials
+using graphical or command line interfaces with git and GitHub][novice-guide] developed by Carpentries Instructors.
+
+The [Help Wanted page][hwp] lists issues in need of attention
+and is a good place to find out where your contributions are most needed.
+
+[novice-guide]: https://github.com/carpentries-incubator/swc_github_flow/blob/main/for_novice_contributors.md#
+[hwp]: https://carpentries.org/help-wanted-issues

--- a/topic_folders/maintainers/contributing.md
+++ b/topic_folders/maintainers/contributing.md
@@ -8,5 +8,5 @@ using graphical or command line interfaces with git and GitHub][novice-guide] de
 The [Help Wanted page][hwp] lists issues in need of attention
 and is a good place to find out where your contributions are most needed.
 
-[novice-guide]: https://github.com/carpentries-incubator/swc_github_flow/blob/main/for_novice_contributors.md#
+[novice-guide]: https://github.com/carpentries-incubator/swc_github_flow/blob/HEAD/for_novice_contributors.md
 [hwp]: https://carpentries.org/help-wanted-issues


### PR DESCRIPTION
Both the name of the repo owner and the branch name had changed.
This PR also uses the linked document's title as the link text and adds [Semantic Line Breaks](https://sembr.org) as suggested by the new [Markdown style guide](https://carpentries.github.io/sandpaper-docs/style.html#line-length).