### PR TITLE
Update repo and branch names in Markdown content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Historically, information and resources related to [The Carpentries](https://carpentries.org/) have been spread across various websites, Google docs, GitHub repos, and more. The handbook is a one-stop shop that consolidates information on running a workshop, developing or maintaining lessons, participating in an instructor training event, and more! 
 
-Many community members have contributed to this handbook, and we welcome feedback on this Handbook. Feel free to submit issues or pull requests to [this GitHub repo](https://github.com/carpentries/handbook/) to improve this community resource.
+Many community members have contributed to this handbook, and we welcome feedback on this Handbook. Feel free to submit issues or pull requests to [this GitHub repo](https://github.com/carpentries/docs.carpentries.org/) to improve this community resource.
 
 
 ### Building this site
@@ -66,13 +66,13 @@ For the `index.rst` files, links must be formatted as follows. Note the text is 
 
 **Links to external markdown documents**
 
-Something in this template causes `.md` extensions to get stripped, breaking links to things like markdown documents in a GitHub repo.  This can be fixed by adding an anchor tag (`#`) to the end of the url.  For example, `https://github.com/carpentries/handbook/blob/topic_folders/file.md` would become `https://github.com/carpentries/handbook/blob/topic_folders/file.md#`. 
+Something in this template causes `.md` extensions to get stripped, breaking links to things like markdown documents in a GitHub repo.  This can be fixed by adding an anchor tag (`#`) to the end of the url.  For example, `https://github.com/carpentries/docs.carpentries.org/blob/topic_folders/file.md` would become `https://github.com/carpentries/docs.carpentries.org/blob/topic_folders/file.md#`. 
 
 
 #### Additional information
 
-This site is built from the main branch of [this repo (carpentries/handbook)](https://github.com/carpentries/handbook/). Changes can be previewed live here: <http://docs-src.carpentries.org/>.  Changes to the actual site <https://docs.carpentries.org/>  can take up to a day to go live once changes have been pushed to GitHub, since the contents of the site are behind a CDN (Content Distribution Network) that caches content.
+This site is built from the main branch of [this repo (carpentries/docs.carpentries.org)](https://github.com/carpentries/docs.carpentries.org/). Changes can be previewed live here: <http://docs-src.carpentries.org/>.  Changes to the actual site <https://docs.carpentries.org/>  can take up to a day to go live once changes have been pushed to GitHub, since the contents of the site are behind a CDN (Content Distribution Network) that caches content.
 
-If you are making experimental changes to content please be sure to do so in a non-main, non-live branch. When your changes are complete and ready to be pushed to the live site, open a pull request in [carpentries/handbook](https://github.com/carpentries/handbook).
+If you are making experimental changes to content please be sure to do so in a non-main, non-live branch. When your changes are complete and ready to be pushed to the live site, open a pull request in [carpentries/docs.carpentries.org](https://github.com/carpentries/docs.carpentries.org).
 
-Draft content can be added to the [drafts folder of the carpentries/userguides repo](https://github.com/carpentries/usersguides/tree/master/drafts) (in the main branch) without breaking anything. Draft content is not built to the live site and these files may contain inaccurate or out of date information.
+Draft content can be added to the [drafts folder of the carpentries/userguides repo](https://github.com/carpentries/usersguides/tree/main/drafts) (in the main branch) without breaking anything. Draft content is not built to the live site and these files may contain inaccurate or out of date information.

--- a/topic_folders/assessment/assessment-network.md
+++ b/topic_folders/assessment/assessment-network.md
@@ -4,7 +4,7 @@
 The Assessment Network was established in October 2016 as a space for those working on assessment within the open source/research computing space to collaborate and share resources.
 
 #### What We Do
-The Assessment Network meets quarterly to discuss best-practices and projects around assessing outcomes in scientific computing. For past meeting information, check out the [minutes](https://github.com/carpentries/assessment/tree/master/assessment-network/minutes) in the Assessment Network [repo](https://github.com/carpentries/assessment/tree/master/assessment-network).
+The Assessment Network meets quarterly to discuss best-practices and projects around assessing outcomes in scientific computing. For past meeting information, check out the [minutes](https://github.com/carpentries/assessment/tree/main/assessment-network/minutes) in the Assessment Network [repo](https://github.com/carpentries/assessment/tree/main/assessment-network).
 
 #### Get Involved
 To join the Assessment Network, email Kari Jordan at [kariljordan@carpentries.org](mailto:kariljordan@carpentries.org).

--- a/topic_folders/communications/guides/submit_blog_post.md
+++ b/topic_folders/communications/guides/submit_blog_post.md
@@ -183,7 +183,7 @@ after completion of the build triggered by this change.
       `![<alt_text>]({{ site.urlimg }}(https://web_address/pathway_to_full_image_filename)_<caption>_`
   
     - If you are not sure how to add images in Markdown format, look at an
-      [existing post with a locally hosted image](https://github.com/datacarpentry/datacarpentry.github.io/blob/master/_posts/2017-12-19-frb_carpentry.md)
+      [existing post with a locally hosted image](https://github.com/datacarpentry/datacarpentry.github.io/blob/main/_posts/2017-12-19-frb_carpentry.md)
       and copy the formatting from there.
      
 13. Once you have completed your changes, you can click on the `Preview` tab to make sure your images are showing.

--- a/topic_folders/communications/resources/comms-implementation-plan.md
+++ b/topic_folders/communications/resources/comms-implementation-plan.md
@@ -33,8 +33,8 @@ For every project, a complete communications plan will be the sum total of four 
 The role of the Community Development team is to help align all of The Carpentries’ communications with our strategy, and empower our community by communicating effectively. To help The Carpentries’ Communications team review your project communications adequately, each project team will schedule an hour-long communications brainstorm session at the onset of their project to talk about Project particulars highlighted in orange. 
 Highlighted in green are existing project details you will need to have before the Communications brainstorm meeting in order for us to collaboratively develop a wholesome communications plan.
 
-![](https://github.com/carpentries/handbook/raw/main/img/comms-images/comms-plan-1.png)
-![](https://github.com/carpentries/handbook/raw/main/img/comms-images/comms-plan-2.png)
+![](https://github.com/carpentries/docs.carpentries.org/raw/main/img/comms-images/comms-plan-1.png)
+![](https://github.com/carpentries/docs.carpentries.org/raw/main/img/comms-images/comms-plan-2.png)
 
 ### Audience Mapping
 
@@ -148,13 +148,13 @@ Each [Carpentries team](https://carpentries.org/team/) member either leads or is
 **What should our Executive Council be communicating and when?**
 
 Formal statements regarding The Carpentries’ policies and finances will only be released by the’ Executive Director or Executive Council Chair. 
-The Executive Council is also responsible for communicating [transparency reports](https://github.com/carpentries/executive-council-info/tree/master/code-of-conduct-transparency-reports) and will also communicate on all other subjects as mandated by their role in their period of tenure. The Secretary of the Executive Council, also regularly publishes [meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes).
+The Executive Council is also responsible for communicating [transparency reports](https://github.com/carpentries/executive-council-info/tree/main/code-of-conduct-transparency-reports) and will also communicate on all other subjects as mandated by their role in their period of tenure. The Secretary of the Executive Council, also regularly publishes [meeting minutes](https://github.com/carpentries/executive-council-info/tree/main/minutes).
 Succinct updates from the Executive Council will continually be added to [Carpentry Clippings](https://carpentries.org/newsletter/) fortnightly, as appropriate.
 
 **What should our Executive Director be communicating and when?**
 
 **Open Letters**
-The Executive Director is responsible for communicating the strategic direction and vision of the organisation, and periodically, [writing open letters](https://github.com/carpentries/conversations/blob/master/letters/ED-letter_2018-01-09.pdf) to the community to inspire, challenge and engage with the community. These open letters will continue to be published in [The Carpentries Conversations repository on GitHub](https://github.com/carpentries/conversations). 
+The Executive Director is responsible for communicating the strategic direction and vision of the organisation, and periodically, [writing open letters](https://github.com/carpentries/conversations/blob/main/letters/ED-letter_2018-01-09.pdf) to the community to inspire, challenge and engage with the community. These open letters will continue to be published in [The Carpentries Conversations repository on GitHub](https://github.com/carpentries/conversations). 
 
 [idea] The communication team’s vision for this initiative is that it evolves into ***a Letters from The Carpentries Team*** series, where we can all share tidbits from our respective desks i.e. on community building, communications, developing curricula, setting up community infrastructure, workshops administration, et al. 
 

--- a/topic_folders/communications/resources/comms-strategy.md
+++ b/topic_folders/communications/resources/comms-strategy.md
@@ -67,7 +67,7 @@ The language we adapt in our communications should embody our "***people first, 
 
 Depending on the subject and context (i.e. audience) of our communications, the tone we use should be an amalgamation of several attributes, some of which are listed in the table below. The Carpentries badge spells out where on the scale the tone of our communications should fall at any given time.
 
-![Communications Tone Scale](https://github.com/carpentries/handbook/raw/main/img/comms-images/comms-tone-scale.png)
+![Communications Tone Scale](https://github.com/carpentries/docs.carpentries.org/raw/main/img/comms-images/comms-tone-scale.png)
 
 The Carpentries messaging is primarily relayed via the following formats: <br><br>
 

--- a/topic_folders/communications/resources/logos.md
+++ b/topic_folders/communications/resources/logos.md
@@ -35,7 +35,7 @@ This policy has been adapted in part from the Python Software Foundation’s [Tr
 
 * [The Carpentries](https://github.com/carpentries/logo)
 * [Data Carpentry](https://github.com/datacarpentry/logos)
-* [Library Carpentry](https://github.com/LibraryCarpentry/lc-styleguide/tree/master/logo)
+* [Library Carpentry](https://github.com/LibraryCarpentry/lc-styleguide/tree/main/logo)
 * [Software Carpentry](https://github.com/swcarpentry/communications/tree/main/misc/logo)
 
 #### Virtual Backgrounds

--- a/topic_folders/for_instructors/new_instructors.md
+++ b/topic_folders/for_instructors/new_instructors.md
@@ -49,7 +49,7 @@ People train as Instructors for many reasons:
 4. *To help get people of diverse backgrounds into the pipeline.* Some of our Instructors are involved in part because they want computational science to include people from a broader range of backgrounds.
 5. *Teaching forces you to learn new things, or learn old things in more detail than you already know.* See this paper: [Graduate Students' Teaching Experiences Improve Their Methodological Research Skills](http://science.sciencemag.org/content/333/6045/1037)".
 6. *To make the world a better place.*
-7. *To acquire useful skills for careers.* Instructors can expect to develop [this skill set](https://github.com/carpentries/commons/blob/master/text-for-instructors.md#). You can re-use and re-purpose this wording for use in grant and job applications and for your CV.
+7. *To acquire useful skills for careers.* Instructors can expect to develop [this skill set](https://github.com/carpentries/commons/blob/main/text-for-instructors.md#). You can re-use and re-purpose this wording for use in grant and job applications and for your CV.
 8. *To join a community* of people who care about inclusive teaching of computational skills.
 9. *Because it is fun.* It really is !
 

--- a/topic_folders/governance/bylaws.md
+++ b/topic_folders/governance/bylaws.md
@@ -161,7 +161,7 @@ All officers must be members of the Executive Council. Officers will be selected
 ### Removal of Officers
 If an officer steps down, is removed from the Executive Council, or is otherwise unable to meet their obligations as determined by the Chair and/or Vice Chair, a new officer will be elected from the remaining Executive Council Members.
 
-A detailed description of the Responsibilities of Executive Council members and officers is described [elsewhere](https://github.com/carpentries/executive-council-info/blob/master/process/roles_responsibilities.md#executive-council-roles-and-responsibilities).
+A detailed description of the Responsibilities of Executive Council members and officers is described [elsewhere](https://github.com/carpentries/executive-council-info/blob/main/process/roles_responsibilities.md#executive-council-roles-and-responsibilities).
 
 ## 8. Committees and Task Forces
 

--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -7,8 +7,8 @@ the Carpentries reports. The Council comprises nine members - four elected by th
 
 The Executive Council is responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image. Members of the Council also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the organisation’s reputation and fundraising. The Executive Council executes these responsibilities through a combination of quarterly Executive Council meetings and regular correspondence and collaboration via email and online platforms. For the full description of the Executive Council’s roles and responsibilities, see the Executive Council section of the [Carpentries Bylaws](bylaws.html#executive-council). 
 
-In addition to [publicly posting meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes), the Executive Council reports on its activities periodically in [Carpentries Clippings](https://carpentries.org/newsletter/) (the organisational newsletter) as well as through [blog posts](https://carpentries.org/posts-by-tags/#blog-tag-governance).
-The Council also prepares [Yearly Summaries](https://github.com/carpentries/executive-council-info/tree/master/year-in-review) of its activities.
+In addition to [publicly posting meeting minutes](https://github.com/carpentries/executive-council-info/tree/main/minutes), the Executive Council reports on its activities periodically in [Carpentries Clippings](https://carpentries.org/newsletter/) (the organisational newsletter) as well as through [blog posts](https://carpentries.org/posts-by-tags/#blog-tag-governance).
+The Council also prepares [Yearly Summaries](https://github.com/carpentries/executive-council-info/tree/main/year-in-review) of its activities.
 
 ### Executive Council Officers
 
@@ -118,7 +118,7 @@ _3. The Executive Council should be informed of (but no decision or advising exp
 
 ### Executive Council Meetings
 
-The Executive Council meets quarterly (i.e. February, May, August, December). Standing Committees hold additional meetings when needed, typically monthly. Minutes of the Executive Council meetings are shared publically in the [executive-council-info repository](https://github.com/carpentries/executive-council-info/tree/master/minutes). Executive Council members are invited to attend the Core Team meetings as needed, and Core Team members attend Standing Committee meetings as needed. A list of issues to be discussed during quarterly Executive Council meetings is provided below. A monthly list of issues to be discussed and tasks to complete outside of quarterly Executive Council meetings is provided in the [Executive Council Work Plan](https://github.com/carpentries/executive-council-info/blob/main/process/workplan.md)
+The Executive Council meets quarterly (i.e. February, May, August, December). Standing Committees hold additional meetings when needed, typically monthly. Minutes of the Executive Council meetings are shared publically in the [executive-council-info repository](https://github.com/carpentries/executive-council-info/tree/main/minutes). Executive Council members are invited to attend the Core Team meetings as needed, and Core Team members attend Standing Committee meetings as needed. A list of issues to be discussed during quarterly Executive Council meetings is provided below. A monthly list of issues to be discussed and tasks to complete outside of quarterly Executive Council meetings is provided in the [Executive Council Work Plan](https://github.com/carpentries/executive-council-info/blob/main/process/workplan.md)
 
 #### February
 * Approve minutes from December meeting

--- a/topic_folders/governance/task-force-policy.md
+++ b/topic_folders/governance/task-force-policy.md
@@ -34,7 +34,7 @@ with a link to its public documentation.
 ### Task Force Operations
 The following are operational guidelines for task forces. Each task force should:
 
-- Create the official [task force charter](https://github.com/carpentries/task-forces/blob/master/task-force-charter-template.md), 
+- Create the official [task force charter](https://github.com/carpentries/task-forces/blob/main/task-force-charter-template.md), 
 including the task force's roles and responsibilities
 - Appoint the task force chair, and, optionally, a co-chair
 - Request a [Core Team](https://carpentries.org/team/) member liaison to serve as a point of contact and (optionally) attend the task force meetings

--- a/topic_folders/hosts_instructors/instructor_tips.md
+++ b/topic_folders/hosts_instructors/instructor_tips.md
@@ -26,11 +26,11 @@ Software installation can be frustrating, but in the end, it almost always gets 
 
 **"Emergency Exits"**
 
-If there is absolutely no way that you will be able to install the software locally on someone's computer, consider using the [following solutions](https://github.com/carpentries/scaffolds/blob/master/instructions/workshop-coordination.md#supporting-learners-with-carpentries-scaffolds):
+If there is absolutely no way that you will be able to install the software locally on someone's computer, consider using the [following solutions](https://github.com/carpentries/scaffolds/blob/main/instructions/workshop-coordination.md#supporting-learners-with-carpentries-scaffolds):
 
 > Read our [blog post, "Scaffolding Installation for Online Workshops"](https://carpentries.org/blog/2020/04/scaffolds/)
 
-* Pre-configured "scaffolds" for [RStudio Cloud](https://github.com/carpentries/scaffolds/blob/master/instructions/workshop-coordination.md#rstudio-cloud) and [My Binder](https://github.com/carpentries/scaffolds/blob/master/instructions/workshop-coordination.md#my-binder) (hosting Jupyter and OpenRefine).
+* Pre-configured "scaffolds" for [RStudio Cloud](https://github.com/carpentries/scaffolds/blob/main/instructions/workshop-coordination.md#rstudio-cloud) and [My Binder](https://github.com/carpentries/scaffolds/blob/main/instructions/workshop-coordination.md#my-binder) (hosting Jupyter and OpenRefine).
 * [Microsoft Azure](https://notebooks.azure.com/) gives you a cloud based Jupyter notebook with many languages and platforms installed.  It also includes a shell terminal with git.
 * If your institution's library does laptop rentals, rent 1-2 laptops and set them up with the software before the workshop and keep them on hand as loaners during the workshop.  
 

--- a/topic_folders/hosts_instructors/resources_for_online_workshops.md
+++ b/topic_folders/hosts_instructors/resources_for_online_workshops.md
@@ -4,7 +4,7 @@ In the wake of COVID-19 in early 2020, The Carpentries community came together t
 
 #### Resources by The Carpentries
 
-The Carpentries convened a [Task Force to address the urgent demand for online Carpentries workshops](https://github.com/carpentries/task-forces/blob/master/2020/COVID-19/COVID-19-charter.md) as communities have shifted to distance work across the globe. The Task Force concluded its work on April 1, with an initial set of guidelines for teaching, supporting, and communicating about fully online versions of all Data Carpentry, Library Carpentry, and Software Carpentry workshops.
+The Carpentries convened a [Task Force to address the urgent demand for online Carpentries workshops](https://github.com/carpentries/task-forces/blob/main/2020/COVID-19/COVID-19-charter.md) as communities have shifted to distance work across the globe. The Task Force concluded its work on April 1, with an initial set of guidelines for teaching, supporting, and communicating about fully online versions of all Data Carpentry, Library Carpentry, and Software Carpentry workshops.
 
 - Official guidelines and recommendations for teaching pilot-phase Carpentries workshops [can be found here on The Carpentries website](https://carpentries.org/online-workshop-recommendations/).
 - April 24, [blog post with information about cloud instances that are now available as backup for learners in Carpentries workshops with installation issues](https://carpentries.org/blog/2020/04/scaffolds/)

--- a/topic_folders/instructor_development/mentoring_groups_workflow.md
+++ b/topic_folders/instructor_development/mentoring_groups_workflow.md
@@ -5,7 +5,7 @@ This workflow was set up to guide the [Instructor Development Committee Mentorin
 ### Preparing to Run Mentoring Groups
 
 - Meet with the Instructor Development Committee to set the dates of the Mentoring Groups
-- Add Mentoring Group dates to README on GitHub. [Instructions](https://github.com/carpentries/mentoring/blob/master/mentoring-groups/README.md)
+- Add Mentoring Group dates to README on GitHub. [Instructions](https://github.com/carpentries/mentoring/blob/main/mentoring-groups/README.md)
 - Update deadlines in the Mentor and Mentee Application forms
 	- [The Carpentries Mentor Application form](https://goo.gl/forms/1AnNC449zDdCpYhI2)
   - [The Carpentries Mentee Application form](https://goo.gl/forms/L6KNCnOIFrAVxhq72)

--- a/topic_folders/instructor_training/email_templates_trainers.md
+++ b/topic_folders/instructor_training/email_templates_trainers.md
@@ -141,13 +141,13 @@ Subject: Carpentries instructor training: Teaching Demo
 
 Hello,
 
-Thanks for signing up to complete your “Teaching Demo” as part of the instructor certification process.  We will meet on [ Insert Date ] at [ Insert Time ] in this Zoom videoconferencing room (insert zoom link here). Please read this short bi-lingual description of how Teaching Demo session works (https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md#). Disclaimer: I understand Spanish better than I speak it. So, I will talk in Spanish as much as I can, but I will most likely give feedback about your teaching in English.
+Thanks for signing up to complete your “Teaching Demo” as part of the instructor certification process.  We will meet on [ Insert Date ] at [ Insert Time ] in this Zoom videoconferencing room (insert zoom link here). Please read this short bi-lingual description of how Teaching Demo session works (https://github.com/carpentries/latinoamerica/blob/main/traducciones/demo.md#). Disclaimer: I understand Spanish better than I speak it. So, I will talk in Spanish as much as I can, but I will most likely give feedback about your teaching in English.
 
 Please let me know if you have any questions or concerns.
 
 Hola,
 
-Gracias por inscribirte para completar tu demostración de enseñanza como parte del proceso de certificación para instructores. Nos reuniremos [ Insert Date ] [ insert time ] aquí: (insert zoom link here). Por favor, lee [ésta breve descripción bilingüe](https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md#) de cómo funciona la sesión de demostración de enseñanza aquí: (https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md#). Aviso: Entiendo el español mejor de lo que hablo. Por lo tanto, voy a hablar en español un poco, pero es muy probable que les dé comentarios sobre su enseñanza en Inglés.
+Gracias por inscribirte para completar tu demostración de enseñanza como parte del proceso de certificación para instructores. Nos reuniremos [ Insert Date ] [ insert time ] aquí: (insert zoom link here). Por favor, lee [ésta breve descripción bilingüe](https://github.com/carpentries/latinoamerica/blob/main/traducciones/demo.md#) de cómo funciona la sesión de demostración de enseñanza aquí: (https://github.com/carpentries/latinoamerica/blob/main/traducciones/demo.md#). Aviso: Entiendo el español mejor de lo que hablo. Por lo tanto, voy a hablar en español un poco, pero es muy probable que les dé comentarios sobre su enseñanza en Inglés.
 
 Por favor, hazme saber si tienes alguna pregunta o inquietud.
 

--- a/topic_folders/maintainers/github_labels.md
+++ b/topic_folders/maintainers/github_labels.md
@@ -7,7 +7,7 @@
 <!-- the canonical definition of the GitHub labels is stored in the CSV    -->
 <!-- where `data/github_labels.csv` is the the canonical definition of     -->
 <!-- the GitHub labels is stored in the CSV  file hosted at:               -->
-<!-- https://github.com/carpentries/docs.carpentries.org/blob/master/data/github_labels.csv -->
+<!-- https://github.com/carpentries/docs.carpentries.org/blob/main/data/github_labels.csv -->
 
 <h3>"status" labels</h3>
 <ul>
@@ -251,7 +251,7 @@ install.packages("remotes")
     remotes::install_github("fmichonneau/chisel")
     ```
 1. Make sure you have downloaded the [CSV file that contains the information
-   about the GitHub labels](https://raw.githubusercontent.com/carpentries/handbook/master/data/github_labels.csv). It is in the repository for The Carpentries handbook
+   about the GitHub labels](https://raw.githubusercontent.com/carpentries/docs.carpentries.org/main/data/github_labels.csv). It is in the repository for The Carpentries handbook
    in the data folder.
 
 1. Load the `chisel` package and create the labels on one repository:

--- a/topic_folders/policies/coc-membership-agreement.md
+++ b/topic_folders/policies/coc-membership-agreement.md
@@ -14,7 +14,7 @@ In order to uphold the CoC, the CoCc members will:
 * support the objectives and mission of The Carpentries by abiding by its CoC and other policies and procedures.
 * learn about the [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#) and [reporting guidelines](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#incident-reporting-guidelines), and as CoC advocates, bring awareness of it into any Community spaces that they are part of.  
 * understand and be comfortable to act on CoC related reports as per the [enforcement guidelines](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual) put in place for the relevant community spaces.
-* actively help develop and maintain existing and new documents to facilitate the work of the [CoCc](https://github.com/carpentries/handbook/tree/master/topic_folders/policies). 
+* actively help develop and maintain existing and new documents to facilitate the work of the [CoCc](https://github.com/carpentries/docs.carpentries.org/tree/main/topic_folders/policies). 
 * avoid *conflicts of interest* [1] when processing CoC related reports. Failure to declare a conflict of interest may be considered a breach of the CoC.
 * maintain the confidentiality of any reported incidents, the identity of persons involved and discussions that take place within the committee.
 * not make any comments about any matters that they have been informed of as part of their duties as a CoCc member unless authorized to do so.

--- a/topic_folders/policies/enforcement-guidelines.md
+++ b/topic_folders/policies/enforcement-guidelines.md
@@ -10,7 +10,7 @@ The committee will make all efforts to meet within two business days to review t
 
 Once the committee has determined its resolution, the original reporter will be contacted to let them know what action (if any) will be taken. The committee will take into account feedback from the reporter on the appropriateness of its response but may decide not to act on that feedback.  
 
-Finally, the Chair of the Code of Conduct Committee and Executive Council Liaison will write up a [transparency report](https://github.com/carpentries/executive-council-info/blob/master/code-of-conduct-transparency-reports/) for incidents reported through the incident report form or other channels. Names of the reporter and any persons involved in the incident will not be included unless the resolution results in a termed suspension. The Executive Council may choose to make a public report of the incident while maintaining anonymity of those involved.
+Finally, the Chair of the Code of Conduct Committee and Executive Council Liaison will write up a [transparency report](https://github.com/carpentries/executive-council-info/blob/main/code-of-conduct-transparency-reports/) for incidents reported through the incident report form or other channels. Names of the reporter and any persons involved in the incident will not be included unless the resolution results in a termed suspension. The Executive Council may choose to make a public report of the incident while maintaining anonymity of those involved.
 
 ##### Terminology
 - **Reporter**: Person reporting an incident.

--- a/topic_folders/regional_communities/carpentries_en_latinoamerica.md
+++ b/topic_folders/regional_communities/carpentries_en_latinoamerica.md
@@ -46,10 +46,10 @@ To contact this group, email [local-latinoamerica@lists.carpentries.org](mailto:
 
 ### Reuniones bilingües / Bilingual Meetings 
 
-- Hacemos reuniones bilingües para la sección "Demostración de enseñanza" de ["Instructor Training Checkout"](https://carpentries.github.io/instructor-training/checkout/). Inscríbase en el [Etherpad](https://pad.carpentries.org/teaching-demos) o lea las [instrucciones bilingües](https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md) para saber cómo funcionan las sesiones de demostración.
+- Hacemos reuniones bilingües para la sección "Demostración de enseñanza" de ["Instructor Training Checkout"](https://carpentries.github.io/instructor-training/checkout/). Inscríbase en el [Etherpad](https://pad.carpentries.org/teaching-demos) o lea las [instrucciones bilingües](https://github.com/carpentries/latinoamerica/blob/main/traducciones/demo.md) para saber cómo funcionan las sesiones de demostración.
 
 - We host bilingual meetings for the "Teaching Demo Sessions"  part of [Instructor Training Checkout](https://carpentries.github.io/instructor-training/checkout/).
-Sign up on the [Etherpad](https://pad.carpentries.org/teaching-demos) or read the [bilingual instructions](https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md) for how the demo sessions work. 
+Sign up on the [Etherpad](https://pad.carpentries.org/teaching-demos) or read the [bilingual instructions](https://github.com/carpentries/latinoamerica/blob/main/traducciones/demo.md) for how the demo sessions work. 
 
 ### Traducciones / Translations
 


### PR DESCRIPTION
Following up on #913 I changed links within the Handbook's content:

- `/handbook/` is now `/docs.carpentries.org/`
- `/master/` is now `/main/` when this was changed.

I checked the repositories to see if the main branch was renamed.
