### PR TITLE
add page with Carpentries-owned GitHub organisations

### DIFF
--- a/topic_folders/communications/tools/github_organisations.md
+++ b/topic_folders/communications/tools/github_organisations.md
@@ -1,0 +1,22 @@
+# GitHub Organisations Owned by The Carpentries
+
+The Carpentries owns many GitHub organisations, used for individual lesson programs and Carpentries-wide work.
+
+* [The Carpentries](https://github.com/carpentries): The Carpentries website, instructor training curriculum, and other materials related to The Carpentries project as a whole.
+* [Data Carpentry](https://github.com/datacarpentry): Curricula and other materials related specifically to the Data Carpentry lesson program.  
+* [Library Carpentry](https://github.com/librarycarpentry): Curricula and other materials related specifically to the Library Carpentry lesson program.  
+* [Software Carpentry](https://github.com/swcarpentry): Curricula and other materials related specifically to the Software Carpentry lesson program.  
+* [The Carpentries - Spanish Translations](https://github.com/carpentries-es): Spanish language lesson transitions that are in development or have been archived. Active lesson translations can be found in the respective lesson program's repo.
+* [Reproducible Science Curriculum](https://github.com/Reproducible-Science-Curriculum): Hosts lessons that started as an independent project from Data Carpentry.  These lessons are not actively developed or taught.
+* [CarpentryCon](https://github.com/carpentrycon) Planning for the bi-annual CarpentryCon event.
+* [CarpentryConnect](https://github.com/carpentryconnect) Planning local and regional Carpentries events.
+* [carpentries-workshops](https://github.com/carpentries-workshops): Future home for workshop website repos (which will include an automated build process).
+* [data-lessons](https://github.com/data-lessons): Community developed lessons in various stages of development.
+* [The Carpentries Lab](https://github.com/carpentries-lab): Future home of peer-reviewed community developed lessons that follow the format of The Carpentries.
+* [carpentries-incubator](https://github.com/carpentries-incubator): A designated space for community members to develop lessons collaboratively.  A central location for lesson development that isn't tied to individual user accounts.
+
+## Past Organisations
+
+Occasionally, our GitHub organisations are moved, merged, or split.
+
+* [carpentrieslab](https://github.com/carpentries-lab): Former home of peer-reviewed community developed lessons. Replaced by [carpentries-lab](https://github.com/carpentries-lab).

--- a/topic_folders/communications/tools/index.rst
+++ b/topic_folders/communications/tools/index.rst
@@ -8,8 +8,8 @@ TOOLS
 
 
    etherpads.md
+   github_organisations.md
    newsletter.md
    slack-and-email.md
    zenodo_communities.md
    zoom_rooms.md
-   github_organisations.md

--- a/topic_folders/communications/tools/index.rst
+++ b/topic_folders/communications/tools/index.rst
@@ -12,3 +12,4 @@ TOOLS
    slack-and-email.md
    zenodo_communities.md
    zoom_rooms.md
+   github_organisations.md


### PR DESCRIPTION
Reference page listing our organisations, that we can link to during instructor checkout.

I included a section for organisations that we don't use any more, knowing that we are thinking about some changes. If there are historical organisations that could be included, let me know.