### PR TITLE
Update etherpads.md

### DIFF
--- a/topic_folders/communications/tools/etherpads.md
+++ b/topic_folders/communications/tools/etherpads.md
@@ -2,7 +2,7 @@
 
 #### General Usage
 
-The Carpentries offers the use of our [Etherpads](https://pad.carpentries.org/) as collaborative note taking tool during workshops, training events, and other Carpentries related events.  A list of our most commonly used pads and other resources can be found on our [pad-of-pads](https://pad.carpentries.org/pad-of-pads).
+The Carpentries offers the use of our [Etherpads](https://pad.carpentries.org/) as collaborative note taking tool during workshops, training events, and other Carpentries related events.  A list of our most commonly used pads and other resources can be found on our [pad-of-pads](https://pad.carpentries.org/pad-of-pads). This list is manually created and typically only includes pads of interest to the general community.  It will not include pads specific to single events or groups.
 
 A new Etherpad can be created by appending a descriptive name to the url `https://pad.carpentries.org/`, such as `https://pad.carpentries.org/committeename`.
 
@@ -12,10 +12,14 @@ Use of this service is restricted to members of The Carpentries community; this 
 
 Users are expected to follow our [code of conduct]( https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).  All content is publicly available under the [Creative Commons Attribution License](https://creativecommons.org/licenses/by/4.0/).
 
-A list of all commonly used Etherpads can be found on our [pad of pads](https://pad.carpentries.org/pad-of-pads). This list is manually created and typically only includes pads of interest to the general community.  It will not include pads specific to single events or groups.
 
 #### Troubleshooting
 
 While Etherpads are generally reliable, you may find an Etherpad not loading as expected.  In this case, you can try appending `/export/html` to an Etherpad's url.  For example, if `https://pad.carpentries.org/committeename` is not loading, it may be possible to recover its text by going to `https://pad.carpentries.org/committeename/export/html`. This text content can then be copied and pasted to a new Etherpad. Note this will not preserve the Etherpad's history.  The chat will often still be active in the broken Etherpad, so it is recommended that you link to the new Etherpad in the broken Etherpad's chat.
 
 If other Etherpad issues arise, please contact us at team@carpentries.org and a team member will help you troubleshoot.
+
+
+#### See Also
+
+[CodiMD](https://docs.carpentries.org/topic_folders/communications/tools/codimd.html) is another collaborative note taking platform used by the community members.


### PR DESCRIPTION
Merged duplicate segments talking about  "list of our most commonly used pads is found at ..." from line 5 and 15.

Added link to the CodiMD at the bottom as a suggested alternative. If anyone reached to the bottom of the page, that might mean that the visitor would like to explore more.
