### PR TITLE
Update codimd.md

### DIFF
--- a/topic_folders/communications/tools/codimd.md
+++ b/topic_folders/communications/tools/codimd.md
@@ -2,8 +2,7 @@
 
 #### General Usage
 
-The Carpentries also offers [CodiMD](https://pad.carpentries.org/) as another collaborative note taking platform.
-CodiMD recognises [Markdown](https://www.markdownguide.org/cheat-sheet/) syntax,
+The Carpentries also offers [CodiMD](https://codimd.carpentries.org/) as another collaborative note taking platform. CodiMD recognises [Markdown](https://www.markdownguide.org/cheat-sheet/) syntax,
 allowing users to utilise simple markup to format the content they add to the shared document.
 
 The CodiMD interface provides three modes:
@@ -70,3 +69,8 @@ Account holders gain access to two features:
 
 If you encounter issues with the CodiMD platform,
 please contact us at team@carpentries.org and a team member will help you troubleshoot.
+
+
+#### See Also
+
+[Etherpad](https://docs.carpentries.org/topic_folders/communications/tools/etherpads.html) is another collaborative note taking platform used by the community members.


### PR DESCRIPTION
Corrected link to the CodiMD.

Added link to the Etherpad at the bottom as a suggested alternative. If anyone reached to the bottom of the page, that might mean that the visitor would like to explore more. Not all visitors would be reading the webpage sequentially starting from Etherpad page and may have reached the CodiMD page directly.
