### PR TITLE
Correct link to carpentrieslab organisation in handbook

### DIFF
--- a/topic_folders/communications/tools/github_organisations.md
+++ b/topic_folders/communications/tools/github_organisations.md
@@ -19,4 +19,4 @@ The Carpentries owns many GitHub organisations, used for individual lesson progr
 
 Occasionally, our GitHub organisations are moved, merged, or split.
 
-* [carpentrieslab](https://github.com/carpentries-lab): Former home of peer-reviewed community developed lessons. Replaced by [carpentries-lab](https://github.com/carpentries-lab).
+* [carpentrieslab](https://github.com/carpentrieslab): Former home of peer-reviewed community developed lessons. Replaced by [carpentries-lab](https://github.com/carpentries-lab).


### PR DESCRIPTION
I spotted a typo in our list of GitHub organisations: both the 'carpentries-lab' and 'carpentrieslab' entries are linked to the carpentries-lab org.