### PR TITLE
Take out twitter

### DIFF
--- a/topic_folders/for_instructors/new_instructors.md
+++ b/topic_folders/for_instructors/new_instructors.md
@@ -75,5 +75,5 @@ To request training as an Instructor, please fill out this [form](https://amy.ca
 Occasionally, open training events offered to the general public may be announced
 in our [mailing list](https://carpentries.topicbox.com/groups/discuss),
 newsletter, [*Carpentry Clippings*](http://eepurl.com/cfODMH), or through
-our [Twitter](https://twitter.com/thecarpentries) feed.
+our [Mastodon](hachyderm.io/@thecarpentries) feed.
 For all other events, seats are reserved for trainees affiliated with member institutions or admitted individually through our Open Instructor Training program.

--- a/topic_folders/instructor_training/email_templates_admin.md
+++ b/topic_folders/instructor_training/email_templates_admin.md
@@ -604,7 +604,7 @@ application has been placed on our waiting list while we grow our capacity.
 If you would like to become a Member, get in touch with memberships@carpentries.org to learn more about how we can help you make the case at
 your organisation. In the meantime, please get involved!  
   - Join our discussion email list (https://carpentries.topicbox.com/groups/discuss)
-  - Follow us on Twitter (@thecarpentries, @datacarpentry, @swcarpentry, and @libcarpentry)
+  - Follow us on Mastodon (hachyderm.io/@thecarpentries)
   - Help at a local workshop (https://carpentries.org/)
   - Learn about our community (https://carpentries.org/community/)
                  

--- a/topic_folders/workshop_administration/email_templates.md
+++ b/topic_folders/workshop_administration/email_templates.md
@@ -129,7 +129,7 @@ Thank you for attending our [ Data/Library/Software ] Carpentry workshop. We hop
 
 Please be sure to complete our post-workshop survey [ link to survey ]. Your answers are essential to allow us to continuously improve our workshops for future learners. 
 
-If you have any other feedback about the workshop, or would like to get involved in The Carpentries community, please contact us (mailto:team@carpentries.org). You can also join The Carpentries Discussion mailing list (https://carpentries.topicbox.com/groups/discuss), follow us on Twitter (https://twitter.com/datacarpentry and https://twitter.com/swcarpentry), and get involved with lesson development on GitHub ( https://github.com/datacarpentry and https://github.com/swcarpentry/ ). 
+If you have any other feedback about the workshop, or would like to get involved in The Carpentries community, please contact us (mailto:team@carpentries.org). You can also join The Carpentries Discussion mailing list (https://carpentries.topicbox.com/groups/discuss), follow us on Mastodon (hachyderm.io/@thecarpentries), and get involved with lesson development on GitHub ( https://github.com/datacarpentry and https://github.com/swcarpentry/ ). 
 
 The Carpentries is is excited to support you as you  continue to develop your data analysis skills!
 


### PR DESCRIPTION
Hi @maneesha, ok, I've made 3 tiny updates which I think are unproblematic.

I found that when I started to edit any pages in the comms folders for tools or guides I quickly got stuck in Carpentries Strategy, ie plans for what and when to post on the appropriate platform. Edits here would probably benefit from a considered approach from @OscarSiba!  

I believe this PR will take the number of pages which need to be changed from 15 down to 12.