### PR TITLE
Handbook updates to reflect reduced Core Team support for CACs

### DIFF
--- a/topic_folders/lesson_development/cac-consult-rubric.md
+++ b/topic_folders/lesson_development/cac-consult-rubric.md
@@ -1,10 +1,10 @@
 ## Curriculum Advisory Committee Consultation Rubric
 
-This rubric defines the division of responsibilities between The Carpentries Maintainers and The Carpentries Curriculum Advisory Committees (CACs). 
-[Roles and responsibilities](https://docs.carpentries.org/topic_folders/lesson_development/curriculum_advisory_committees.html#roles-and-responsibilities) 
-of Curriculum Advisory Committee members are documented elsewhere in this Handbook. 
-Current committee membership for [Data Carpentry](https://datacarpentry.org/curriculum-advisors/), 
-[Library Carpentry](https://librarycarpentry.org/cac/), and [Software Carpentry](https://software-carpentry.org/curriculum-advisors/) 
+This rubric defines the division of responsibilities between The Carpentries Maintainers and The Carpentries Curriculum Advisory Committees (CACs).
+[Roles and responsibilities](https://docs.carpentries.org/topic_folders/lesson_development/curriculum_advisory_committees.html#roles-and-responsibilities)
+of Curriculum Advisory Committee members are documented elsewhere in this Handbook.
+Current committee membership for [Data Carpentry](https://datacarpentry.org/curriculum-advisors/),
+[Library Carpentry](https://librarycarpentry.org/cac/), and [Software Carpentry](https://software-carpentry.org/curriculum-advisors/)
 can be found on the respective Lesson Program websites.
 
 ### Issues over which Maintainers have full authority and which do not need CAC involvement
@@ -22,22 +22,26 @@ can be found on the respective Lesson Program websites.
 - Any major adjustments to the lesson (e.g., episode order, passwordless access)
 - Any updates to a lesson that Maintainers wish to share for informational purposes
 
-### Issues that may benefit from Maintainers consulting with the CAC, but over which Maintainers retain authority 
+_What to do if your curriculum does not have an active CAC?_ Maintainers do not need to notify anyone when handling issues described in the list above. ([View the list of active CACs on The Carpentries website](https://carpentries.org/curriculum-advisors/).)
+
+### Issues that may benefit from Maintainers consulting with the CAC, but over which Maintainers retain authority
 
 - Addition of a new library or package
 - Introduction of a new topic / learning objective (e.g., [adding file permissions to LC shell lesson](https://github.com/LibraryCarpentry/lc-shell/issues/63))
 - Updates to software/packages that are minor versions (e.g., Python 3.7 -> 3.8) when the new version is backwards compatible with current version
 - Additions of experimental features (e.g., `git checkout` → `git restore` / `git switch`)
 - Any change to a lesson that impacts the content/scope of another lesson in the curriculum
-- For Incubator lessons - Review of a lesson outline where lesson developers would like the lesson to be considered for eventual adoption into 
+- For Incubator lessons - Review of a lesson outline where lesson developers would like the lesson to be considered for eventual adoption into
 a Lesson Program’s official curriculum
 - Issues which are not covered anywhere else in this rubric
 
+_What to do if your curriculum does not have an active CAC?_ Maintainers may consult the Curriculum Team ([by email](mailto:curriculum@carpentries.org) or tagging the `core-team-curriculum` team on the relevant GitHub issue/pull request/discussion) and/or the wider community when handling issues described in the list above. For example, where more perspectives are needed, it may be helpful to use [relevant communication channels](https://carpentries.org/connect/) to call for input and feedback from the Instructor community. ([View the list of active CACs on The Carpentries website](https://carpentries.org/curriculum-advisors/).)
+
 ### Issues for which Maintainers must seek CAC approval
 
-- Replacing the dataset used in the lesson with a different dataset. This does not include cases in which the data being used in the lesson is being updated to a 
-new version (e.g., a new data release) or is modified to make it more suitable for the teaching environment 
-(e.g., introduction of messiness to the dataset). 
+- Replacing the dataset used in the lesson with a different dataset. This does not include cases in which the data being used in the lesson is being updated to a
+new version (e.g., a new data release) or is modified to make it more suitable for the teaching environment
+(e.g., introduction of messiness to the dataset).
 - Changing the software being used in the lesson. This does not include updating to a new stable, backwards-compatible version of the
 existing software (e.g., Python  3.6 → 3.7.x), but does include:
   - Updating to a non-backwards compatible version of existing software (e.g., Python 2.x → 3.x, R 3.x → 4.x)
@@ -45,11 +49,13 @@ existing software (e.g., Python  3.6 → 3.7.x), but does include:
   - Change in libraries / packages taught (i.e., removal or replacement)
   - Change in SQL dialect (e.g., SQLite, MySQL, PostgreSQL, MSSQL Server)
   - Change in IDE being used to teach the lessons (RStudio, Jupyter Notebook)
-  - Change from GitHub as remote hosting platform to a different remote hosting platform, e.g., GitLab 
+  - Change from GitHub as remote hosting platform to a different remote hosting platform, e.g., GitLab
 - Removal of an entire episode’s worth of content
 - Change in lesson infrastructure (e.g., moving Genomics lessons from AWS to CyVerse)
 - Retirement of a lesson (e.g., MATLAB, Mercurial)
 - Addition of a new lesson to the core curriculum (e.g., adding Julia as an alternative to R / Python)
 - Adding or removing prerequisites from a lesson (for curricula with multiple lessons)
-- Promotion or graduation of a lesson from alpha to beta to stable. Decisions on approval can be based on recommendations from the Curriculum Team, 
+- Promotion or graduation of a lesson from alpha to beta to stable. Decisions on approval can be based on recommendations from the Curriculum Team,
 CAC member involvement in lesson pilot workshops, and/or open peer review of lessons in The Carpentries Lab.
+
+_What to do if your curriculum does not have an active CAC?_ Maintainers should consult the Curriculum Team ([by email](mailto:curriculum@carpentries.org) or tagging the `core-team-curriculum` team on the relevant GitHub issue/pull request/discussion) when handling issues described in the list above. The Curriculum Team will coordinate and facilitate a discussion among community members likely to be affected by the changes (other Maintainers, Instructors, etc). ([View the list of active CACs on The Carpentries website](https://carpentries.org/curriculum-advisors/).)

--- a/topic_folders/lesson_development/cac-consult-rubric.md
+++ b/topic_folders/lesson_development/cac-consult-rubric.md
@@ -3,9 +3,7 @@
 This rubric defines the division of responsibilities between The Carpentries Maintainers and The Carpentries Curriculum Advisory Committees (CACs).
 [Roles and responsibilities](https://docs.carpentries.org/topic_folders/lesson_development/curriculum_advisory_committees.html#roles-and-responsibilities)
 of Curriculum Advisory Committee members are documented elsewhere in this Handbook.
-Current committee membership for [Data Carpentry](https://datacarpentry.org/curriculum-advisors/),
-[Library Carpentry](https://librarycarpentry.org/cac/), and [Software Carpentry](https://software-carpentry.org/curriculum-advisors/)
-can be found on the respective Lesson Program websites.
+[Current committee membership can be found on The Carpentries website](https://carpentries.org/curriculum-advisors/).
 
 ### Issues over which Maintainers have full authority and which do not need CAC involvement
 

--- a/topic_folders/lesson_development/curriculum_advisory_committees.md
+++ b/topic_folders/lesson_development/curriculum_advisory_committees.md
@@ -1,15 +1,15 @@
 ## Curriculum Advisory Committees
 
 Curriculum Advisors are part of a team that provides the oversight, vision, and leadership for a particular set of lessons.
-The division of responsibilities between Curriculum Advisors and Maintainers is detailed 
+The division of responsibilities between Curriculum Advisors and Maintainers is detailed
 in [this consultation rubric](https://docs.carpentries.org/topic_folders/lesson_development/cac-consult-rubric.html).
 
 Curriculum Advisors represent The Carpentries community and should strive to embody The Carpentries philosophy by:
 
 - Recognising the importance of communication and being welcoming to all contributors.
 - Giving feedback to contributors using The Carpentries model:
-  -  Finding what is good. 
-  -  Being specific about improvements needed. 
+  -  Finding what is good.
+  -  Being specific about improvements needed.
   -  Using motivational language.
 - Evaluating lesson contributions in light of The Carpentries pedagogical model:
   - Teaching what is most relevant and useful for learners.
@@ -18,7 +18,7 @@ Curriculum Advisors represent The Carpentries community and should strive to emb
   - Emphasising the importance of continued learning and improvement.
 
 ### Meetings
-Each Curriculum Advisory Committee will meet at least quarterly, and preferably every two months. These meetings are the primary avenue through which CAC members will interact, and should follow best practices for The Carpentries meetings, including having meeting roles, taking notes, and creating and holding a space for everyone to contribute. CAC members should prepare for meetings by reading and contributing to relevant documents in advance of the meeting. 
+Each Curriculum Advisory Committee will meet at least quarterly, and preferably every two months. These meetings are the primary avenue through which CAC members will interact, and should follow best practices for The Carpentries meetings, including having meeting roles, taking notes, and creating and holding a space for everyone to contribute. CAC members should prepare for meetings by reading and contributing to relevant documents in advance of the meeting.
 
 A detailed workflow for Curriculum Advisory Committee meetings, including email templates, is available as a [meeting checklist](CAC_meeting_checklist.md).
 
@@ -38,51 +38,51 @@ Meetings minutes are available in the committee's GitHub repository:
 - Serve as primary point of contact for Maintainers
 - Watch lesson repositories for instances where the CAC is mentioned. Respond in a timely fashion, including letting Maintainers and contributors know when items are going to be considered at the next meeting.
 - Generally watch lesson repositories for items that may come under the CAC’s purview, according to the CAC consultation rubric, even if not mentioned.
-- Communicate with lesson Maintainers and contributors, through GitHub issues, about decisions made by the CAC. Put contributors and Maintainers in touch with CAC members who will assist with implementation. 
-- Notify Curriculum Team Lead ([Toby Hodges](mailto:tobyhodges@carpentries.org)) if a CAC member needs to step down mid-term or becomes unresponsive to communications, so that Core Team can help recruit replacement if needed. 
-- Approve meeting minutes. 
-- Fulfill all other responsibilities of a CAC member. 
+- Communicate with lesson Maintainers and contributors, through GitHub issues, about decisions made by the CAC. Put contributors and Maintainers in touch with CAC members who will assist with implementation.
+- Notify Curriculum Team Lead ([Toby Hodges](mailto:tobyhodges@carpentries.org)) if a CAC member needs to step down mid-term or becomes unresponsive to communications, so that Core Team can help recruit replacement if needed.
+- Approve meeting minutes.
+- Fulfill all other responsibilities of a CAC member.
 
 #### Secretary
-- Schedule regular meetings. 
-- Arrange meeting room logistics. 
-- Send calendar invites. 
-- Send meeting reminders. 
-- Prepare meeting minutes and post to the appropriate CAC repository. 
-- Fulfill all other responsibilities of a CAC member. 
+- Schedule regular meetings.
+- Arrange meeting room logistics.
+- Send calendar invites.
+- Send meeting reminders.
+- Prepare meeting minutes and post to the appropriate CAC repository.
+- Fulfill all other responsibilities of a CAC member.
 
 #### Other members
 - Notify Chair of potential agenda items as they arise.
 - Read agenda and other relevant documents sent by Chair prior to meeting.
 - Attend and actively participate in regular meetings by listening and sharing knowledge, expertise, ideas, and information.
-- Participate in asynchronous voting through GitHub as needed. 
+- Participate in asynchronous voting through GitHub as needed.
 - Work with community members and Maintainers to implement voted upon changes as needed.
-- (Optional) Be involved in discussions on GitHub with Maintainers and community members when CAC is mentioned. 
+- (Optional) Be involved in discussions on GitHub with Maintainers and community members when CAC is mentioned.
 
 ### Term lengths, recruitment, and onboarding
 
-- Curriculum Advisors are expected to serve a two-year term. 
-- We understand that circumstances can change and priorities must be re-evaluated. If a Curriculum Advisor needs to step away from the role before the end of their two-year term, the Curriculum Team will support them to do this: 
-  - after the first year, the Curriculum Team will approach Curriculum Advisors to confirm that they wish to continue in the role or to step back.
+- Curriculum Advisors are expected to serve a two-year term.
+- We understand that circumstances can change and priorities must be re-evaluated. If a Curriculum Advisor needs to step away from the role before the end of their two-year term, the Curriculum Team will support them to do this:
   - if an Advisor needs to step away from the role outside this schedule, they should inform their committee Chair and [the Curriculum Team](mailto:curriculum@carpentries.org).
 
-- CAC recruitment takes place annually, based on term limits and turnover within committees.
-- Rounds of recruitment will be announced on [The Carpentries blog](https://carpentries.org/blog/).
-- Volunteers will be asked to apply for the role by filling in a short webform describing their expertise and motivation for joining a committee.
-- Templates and workflows for CAC recruitment and onboarding are maintained in [the Core Team wiki (internal access only)](https://github.com/carpentries/core-team-wiki/tree/main/curriculum).
+- Curriculum Advisory Committee recruitment and onboarding coordinated by the Curriculum Team is currently on hold due to limited capacity in the Core Team. Re-establishment of this support for CACs will be prioritised when the capacity of the Curriculum Team increases.
+- While Core Team-led recruitment is unavailable, Curriculum Advisory Committees are encouraged to recruit and onboard their own new members.
+- Rounds of recruitment can be announced on [The Carpentries blog](https://carpentries.org/blog/), but addition of new members by other means (e.g. through personal invitation) is also permitted.
+  - For examples of how calls for Curriculum Advisors have been published in the past, see the blog posts from [2021](https://carpentries.org/blog/2021/09/curriculum-advisory-committee-application/) ([source file](https://github.com/carpentries/carpentries.org/blob/main/_posts/2021/09/2021-09-14-curriculum-advisory-committee-application.md)) and [2022](https://carpentries.org/blog/2022/06/curriculum-advisor-committee-applications/) ([source file](https://github.com/carpentries/carpentries.org/blob/main/_posts/2022/06/2022-06-30-curriculum-advisor-committee-applications.md).
+  - You can also view [a copy of the form used to collect Curriculum Advisor volunteer applications in 2022](https://docs.google.com/forms/d/e/1FAIpQLSeIsw1MZM9932cd2DXnS8MHGIMF6RfNZjqzadDGYOIH96OFdw/viewform?usp=sharing).
+- If and when a new member is added to an existing committee, the committee Chair should inform [the Curriculum Team](mailto:curriculum@carpentries.org), who will update The Carpentries website and internal database to reflect the change.
 
 - Onboarding aims to provide new Curriculum Advisors with context for the role and how CACs fit into The Carpentries model for curriculum development and maintenance, and what they can expect as they prepare to join their first committee meeting.
-- Onboarding for Curriculum Advisors takes place in two parts:
+- Curriculum Team-led onboarding for Curriculum Advisors has taken place in two parts:
   1. A general onboarding for all Curriculum Advisors
   2. An additional onboarding for the committee officers (see _Roles and responsibilities_ above)
-- Both onboardings are delivered by the Curriculum Team over Zoom, with the possibility to watch a recording of the sessions available for those who cannot attend the synchronous sessions.
 - Links to onboarding slides:
   - [general onboarding slides](https://docs.google.com/presentation/d/1xuMCP43EUvmFqvHDX9w4BwOdvWMDcjW0BGxyOQVFSBs/edit?usp=sharing)
   - [officer onboarding slides](https://docs.google.com/presentation/d/1XZmV-EfYXnMo2H2aBqqJo1eIMP1kpzeX5pherky-Cho/edit?usp=sharing)
-- After these onboarding sessions, Curriculum Advisors should complete the following steps:
+- When a new Curriculum Advisor joins a committee, they should complete the following steps:
   1. [Log into AMY](https://amy.carpentries.org/) with their GitHub credentials and update their profile.
      - When updating their AMY profile, it is essential that Advisors give consent for The Carpentries to publish their profile so that they can be listed on The Carpentries websites.
-  2. Join the mailing list for their committee on [The Carpentries TopicBox](https://carpentries.topicbox.com/groups). CAC mailing lists are named with the prefix "curriculum-advisors-". 
+  2. Join the mailing list for their committee on [The Carpentries TopicBox](https://carpentries.topicbox.com/groups). CAC mailing lists are named with the prefix "curriculum-advisors-".
      - These mailing lists are configured so that anyone can send a message to them, but list membership is moderated so that only current members of the committee will receive messages sent to the group.
   3. Subscribe to notifications from the GitHub repositories for the lessons in their curriculum.
      - This step is only _required_ for CAC chairs, but is recommended for all Curriculum Advisors as a way to stay up-to-date about discussions and developments taking place on their curriculum.
@@ -94,4 +94,3 @@ Meetings minutes are available in the committee's GitHub repository:
 ### Current Curriculum Advisors
 
 Refer to [The Carpentries Curriculum Advisors page](https://carpentries.org/curriculum-advisors/) for a current list of Curriculum Advisors and contact information.
-


### PR DESCRIPTION
1. Adjusts the information on recruitment and onboarding for Curriculum Advisors
2. Adds guidance for Maintainers on what to do in cases where they have no active CAC