### PR TITLE
update governance toc with guidelines, not policy

### DIFF
--- a/topic_folders/governance/index.rst
+++ b/topic_folders/governance/index.rst
@@ -7,8 +7,8 @@ Governance
 
    bylaws.md
    executive-council.md
-   committee-policy.md
-   task-force-policy.md
+   committee-guidelines.md
+   task-force-guidelines.md
    lesson-program-policy.md
    lesson-program-governors.md
 


### PR DESCRIPTION
PRs #953 and #954 were put in to change the Task Force and Committee policies to guidelines.  This PR updates the Governance TOC accordingly.