### PR TITLE
Add descriptions for curriculum resources

### DIFF
--- a/source/handbooks/lesson_developers.md
+++ b/source/handbooks/lesson_developers.md
@@ -249,7 +249,7 @@ steps:
 1. Check the [eligibility criteria for lessons to be reviewed in the
    Lab](https://github.com/carpentries-lab/reviews#what-makes-a-lesson-a-good-candidate-for-the-carpentries-lab).
 2. Open a new issue on the [Reviews
-   repository]h(ttps://github.com/carpentries-lab/reviews/issues/new?assignees=&labels=new-submission&template=submission.md&title=%5BREV%5D%3A+)
+   repository](https://github.com/carpentries-lab/reviews/issues/new?assignees=&labels=new-submission&template=submission.md&title=%5BREV%5D%3A+)
    and answer the questions in the issue template to tell the Editors
    about the lesson.
 
@@ -273,7 +273,6 @@ the latest changes to the infrastructure.
 
 ### [Collaborative Lesson Development Training Curriculum](https://carpentries.github.io/lesson-development-training/)
 
-
 A lesson designed to teach skills and good practices in lesson design,
 lesson website development, and collaboration via GitHub. Community
 members can apply to join this training, and/or follow the curriculum in
@@ -294,6 +293,8 @@ with learners in place of the standard post-workshop survey.
 
 ### {{'[Lesson Pilot Workshops]({}/resources/curriculum/lesson-pilots.html)'.format(handbook_url)}}
 
+Information about why and how we test new lessons in workshops, including guidance and templates for hosts and instructors of pilot workshops to use.
+
 ### Beta Announcement Templates
 
 A [template beta announcement blog
@@ -306,4 +307,8 @@ ongoing development of the lesson.
 
 ### {{'[Curriculum Onboarding Materials]({}/resources/curriculum/curriculum_onboarding.html)'.format(handbook_url)}}
 
+Guidance for developing materials that will help instructors prepare to teach your new lesson or curriculum.
+
 ### {{'[Lesson Release Process]({}/resources/curriculum/lesson-release.html)'.format(handbook_url)}}
+
+A description of how to prepare a lesson release and publish it to Zenodo.

--- a/source/handbooks/maintainers.md
+++ b/source/handbooks/maintainers.md
@@ -257,11 +257,13 @@ their lesson.
 A collection of recommendations for community members who want to organise events dedicated to the development and improvement of a lesson. Includes lists of things to consider doing before, during, and after a development sprint, and tools and other resources to support its success.
 
 ### {{'[Lesson Release Process]({}/resources/curriculum/lesson-release.html)'.format(handbook_url)}}
-
+A description of how to prepare a lesson release and publish it to Zenodo.
+**Note that Maintainers of Data Carpentry, Library Carpentry, and Software Carpentry lessons should not make lesson releases for now.**
+The Curriculum Team will coordinate this process in the coming months.
 
 ### [Lesson Developer Handbook](/handbooks/lesson_developers.md)
 
-The handbook for community members developing new lessons includes information, guidance, and further resources that may also be interesting to Mainatiners.
+The handbook for community members developing new lessons includes information, guidance, and further resources that may also be interesting to Maintainers.
 
 
 ### [Collaborative Lesson Development Training Curriculum](https://carpentries.github.io/lesson-development-training/)

--- a/source/resources/curriculum/index.md
+++ b/source/resources/curriculum/index.md
@@ -7,8 +7,8 @@
 * [The Life Cycle of Lessons](lesson-life-cycle.md): A description of the "life cycle" model we use to describe the maturity of lessons under development, and a list of resources and activities that can be helpful at each stage of the process.
 * [Releasing a Lesson](lesson-release.md): A description of how to prepare a lesson release and publish it to Zenodo.
 * [Carpentries Curriculum Structure](curriculum-structure.md): An overview of how lessons and curricula are organised in The Carpentries.
-* [Lesson Pilot Workshops](lesson-pilots)
-* {{'[Curriculum Onboarding Materials]({}/resources/curriculum/curriculum_onboarding.html)'.format(handbook_url)}}
-* [Lesson Program Policy](lesson-program-governance.md)
-* [Lesson Programs](lesson-programs.md)
+* [Lesson Pilot Workshops](lesson-pilots): Information about why and how we test new lessons in workshops, including guidance and templates for hosts and instructors of pilot workshops to use.
+* {{'[Curriculum Onboarding Materials]({}/resources/curriculum/curriculum_onboarding.html)'.format(handbook_url)}}: Guidance for developing materials that will help instructors prepare to teach your new lesson or curriculum.
+* [Lesson Program Policy](lesson-program-governance.md): Information about how The Carpentries Lesson Programs should be governed.
+* [Lesson Programs](lesson-programs.md): Information about the role Lesson Programs take within The Carpentries, how these projects are hosted by the organisation, and the process a project can go through to join The Carpentries as a new Lesson Program.
 

--- a/source/resources/curriculum/index.md
+++ b/source/resources/curriculum/index.md
@@ -1,14 +1,14 @@
 # Curriculum Resources 
 
-* [Curriculum Overview Pages](workshop-overview-lessons.md): Learn about how and why to create a lesson site as a "front page" to a curriculum that combines multiple lessons.
-* [Forking a Lesson Repository](lesson-forks.md): Guidance on how to set up your own fork of a Carpentries Workbench lesson repository.
-* [Lesson Development Roles](lesson-development-roles.md): Learn about the different roles that people can take up during the lesson development process, why they are important, and what resources are available to support them.
-* [Lesson Sprint Recommendations](lesson-sprint-recommendations.md): A collection of recommendations for community members who want to organise events dedicated to the development and improvement of a lesson. Includes lists of things to consider doing before, during, and after a development sprint, and tools and other resources to support its success.
-* [The Life Cycle of Lessons](lesson-life-cycle.md): A description of the "life cycle" model we use to describe the maturity of lessons under development, and a list of resources and activities that can be helpful at each stage of the process.
-* [Releasing a Lesson](lesson-release.md): A description of how to prepare a lesson release and publish it to Zenodo.
 * [Carpentries Curriculum Structure](curriculum-structure.md): An overview of how lessons and curricula are organised in The Carpentries.
+* [Curriculum Overview Pages](workshop-overview-lessons.md): Learn about how and why to create a lesson site as a "front page" to a curriculum that combines multiple lessons.
+* [The Life Cycle of Lessons](lesson-life-cycle.md): A description of the "life cycle" model we use to describe the maturity of lessons under development, and a list of resources and activities that can be helpful at each stage of the process.
+* [Forking a Lesson Repository](lesson-forks.md): Guidance on how to set up your own fork of a Carpentries Workbench lesson repository.
+* [Releasing a Lesson](lesson-release.md): A description of how to prepare a lesson release and publish it to Zenodo.
+* [Lesson Development Roles](lesson-development-roles.md): Learn about the different roles that people can take up during the lesson development process, why they are important, and what resources are available to support them.
 * [Lesson Pilot Workshops](lesson-pilots): Information about why and how we test new lessons in workshops, including guidance and templates for hosts and instructors of pilot workshops to use.
+* [Lesson Sprint Recommendations](lesson-sprint-recommendations.md): A collection of recommendations for community members who want to organise events dedicated to the development and improvement of a lesson. Includes lists of things to consider doing before, during, and after a development sprint, and tools and other resources to support its success.
 * {{'[Curriculum Onboarding Materials]({}/resources/curriculum/curriculum_onboarding.html)'.format(handbook_url)}}: Guidance for developing materials that will help instructors prepare to teach your new lesson or curriculum.
-* [Lesson Program Policy](lesson-program-governance.md): Information about how The Carpentries Lesson Programs should be governed.
 * [Lesson Programs](lesson-programs.md): Information about the role Lesson Programs take within The Carpentries, how these projects are hosted by the organisation, and the process a project can go through to join The Carpentries as a new Lesson Program.
+* [Lesson Program Policy](lesson-program-governance.md): Information about how The Carpentries Lesson Programs should be governed.
 

--- a/source/resources/curriculum/lesson-release.md
+++ b/source/resources/curriculum/lesson-release.md
@@ -1,4 +1,6 @@
 # Releasing a Lesson
+**Note that Maintainers of Data Carpentry, Library Carpentry, and Software Carpentry lessons should not make lesson releases for now.**
+The Curriculum Team will coordinate this process in the coming months.
 
 Making regular releases of your lesson gives you and your contributors an opportunity to celebrate the improvements that have been made, and make it easier for them to receive credit and recognition for the work they have put in.
 It is particularly important to release the lesson when it reaches key milestones in its development, e.g. before [beta pilot workshops](lesson-pilots.md) or when it reaches [a stable state](./lesson-life-cycle.md).


### PR DESCRIPTION
Some of the new curriculum resources do not yet have a description. This PR adds these, and includes a couple of other minor fixes. 