### PR TITLE
Updated TOC links to master DOIs

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -16,9 +16,9 @@ Highlighted Resources
 
     The Carpentries Slack workspace <https://carpentries.slack.com>
     Carpentries Clippings (newsletter) <https://carpentries.org/newsletter>
-    Welcome Tip Sheet <https://zenodo.org/records/10785524>
+    Welcome Tip Sheet <https://doi.org/10.5281/zenodo.8124923>
     Instructor Tip Sheet <https://doi.org/10.5281/zenodo.8125137>
-    Mastodon Quick Start Guide  <https://zenodo.org/records/14170125>
+    Mastodon Quick Start Guide  <https://doi.org/10.5281/zenodo.10019852>
     A Guide for Collaborating with The Carpentries on Grants <resources/general/collaborating-on-grants>
     Donation Request Resources <resources/general/donation-request-resources>
 
@@ -34,7 +34,7 @@ Quick Links
     Community Calendar <https://carpentries.org/community/events/>
     Etherpad Pad of Pads <https://pad.carpentries.org/pad-of-pads>
     Self-Organised Workshop Notification Form <https://amy.carpentries.org/forms/self-organised/>
-    Toolkit of IDEAS  <https://zenodo.org/records/10391883>
+    Toolkit of IDEAS  <https://doi.org/10.5281/zenodo.7041934>
     Workshop Website Template <https://github.com/carpentries/workshop-template>
     Training Website Template <https://github.com/carpentries/training-template>
 


### PR DESCRIPTION
Linked TOC entries to master DOIs (instead of specific Zenodo records) so that the latest entry is always displayed.

Resolution to issue #288.

Please note that I did not see a gh-pages branch to fork from, as indicated in the Contributing Guidelines > [Using GitHub](https://github.com/carpentries/.github/blob/9e2cf116b0d7d90609d5e611dda604a8c53f41ee/CONTRIBUTING.md#using-github)  (<< Note that this URL seems unusual and is referenced from the https://github.com/carpentries/docs.carpentries.org/pulls page in the upper header section "First time contributing...")

Best,
Bob
