### PR TITLE
add css to print full links

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -84,3 +84,13 @@ p.footer-left,  p.title.logo__title, p.copyright, p.theme-version, p.sphinx-vers
 .bd-header-announcement {
     background-color: orangered;
 }
+
+@media print {
+	a,
+	a:visited {
+		text-decoration: underline;
+	}
+	a[href]:after {
+		content: ' (' attr(href) ')';
+	}
+}


### PR DESCRIPTION
Following suggestion in #201, this adds css so that when the page is printed, the full links are displayed.