### PR TITLE
update text for sharing comms link

### DIFF
--- a/source/resources/communications/index.md
+++ b/source/resources/communications/index.md
@@ -7,7 +7,7 @@
 
 ## Communication spaces
 
-* [Guide to sharing resources](sharing_resources.md)
+* [Guide to Sharing Communications with The Carpentries](sharing_resources.md)
 * [Slack](slack-and-email.md#slack-quick-start-guide)
 * [Mailing lists (Topicbox)](slack-and-email.md#topicbox)
 * [Zoom](zoom_rooms.md)


### PR DESCRIPTION
Changes text for sharing comms link as requested in #351.
The other change was already made and should be visible after the next build.