### PR TITLE
Update glossary links to handbook

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -191,7 +191,7 @@ myst_substitutions = {
   "lesson_development_training": "https://carpentries.github.io/lesson-development-training",
 
   # General resources
-  "glossary": "https://github.com/carpentries/community-engagement/blob/main/glossary.md",
+  "glossary": handbook_url + "resources/general/glossary.html",
   "code_of_conduct": handbook_url + "policies/coc/",
   "donate": "https://www.zeffy.com/en-US/donation-form/donate-to-make-a-difference-7497",
   "topicbox_guide": "https://docs.google.com/document/d/1lk1KmImG-5nkYzukjFMZMTS4BEVaOkqBg5_V_aj85_U/",

--- a/source/handbooks/board_of_directors.md
+++ b/source/handbooks/board_of_directors.md
@@ -3,7 +3,7 @@
 ## About This Handbook
 
 This handbook provides useful information about how The Carpentries functions in collaboration with the  Board of Directors including the mission and programs of The Carpentries, the governing documents and policies of The Carpentries and Board, and the general and specific roles and responsibilities of the Board, Core Team and community. This document will be reviewed annually by the Governance and Personnel Committee and updated as needed. To provide feedback on its content, email
-{{'[{}](mailto:{})'.format(team_email, team_email)}}.
+{{'[{}](mailto:{})'.format(team_email, team_email)}}.   If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
 
 
 ## Introduction

--- a/source/handbooks/community_session_host.md
+++ b/source/handbooks/community_session_host.md
@@ -78,8 +78,7 @@ Discussion Host mailing list.
 This section includes a list of communication channels and collaboration
 spaces that support Community Discussion Hosts. Participants in these
 spaces are expected to follow {{"[The Carpentries Code of Conduct]({})".format(code_of_conduct)}}. 
-A description of the tools listed can be found in [the community
-glossary](https://github.com/carpentries/community-development/blob/main/glossary.md).
+A description of the tools listed can be found in the {{'[community glossary]({})'.format(glossary)}}.
 
 ### Community Calendar
 

--- a/source/resources/communications/sharing_resources.md
+++ b/source/resources/communications/sharing_resources.md
@@ -16,7 +16,7 @@ Please follow the [Carpentries Style Guide](https://docs.carpentries.org/resourc
 * If your communication includes videos, provide accurate captions and transcripts for the content.  
 * Make sure that links and buttons are clearly labelled and distinguishable. Avoid using generic phrases like "click here" instead of descriptive text.
 
-When defining terminology popular with The Carpentries community, please use the definitions in our [Community Glossary of Terms](https://docs.carpentries.org/resources/general/glossary.html).  
+When defining terminology popular with The Carpentries community, please use the definitions in our {{'[Community Glossary of Terms]({})'.format(glossary)}}.
 
 ### Single-Authored Blog Post Writing
 

--- a/source/resources/curriculum/curriculum-structure.md
+++ b/source/resources/curriculum/curriculum-structure.md
@@ -3,8 +3,7 @@
 The Carpentries contains multiple _Lesson Programs_ (Data Carpentry, Library Carpentry, Software Carpentry). Each _Lesson Program_ contains at least one _curriculum_. A curriculum is composed of one or more _lessons_.
 Lessons are built from a series of _episodes_.
 
-More detailed definitions of these terms are available in [the community glossary](https://github.com/carpentries/community-development/blob/main/glossary.md).
-
+More detailed definitions of these terms are available in the {{'[Community Glossary of Terms]({})'.format(glossary)}}.
 
 ![The structure of curricula in The Carpentries](img/curriculum-structure.png "schematic showing that a lesson program includes one or more curricula, which each include one or more lessons, which each include one or more episodes.")
 


### PR DESCRIPTION
Updates glossary links to the handbook instead of the old community repo.  Addresses #353.