### PR TITLE
Comprehensive style guide updates for Workshops Resources

### DIFF
--- a/source/resources/curriculum/lesson-sprint-recommendations.md
+++ b/source/resources/curriculum/lesson-sprint-recommendations.md
@@ -14,7 +14,7 @@ These recommendations were written with a particular focus on sprints taking pla
 
 ### Target Audience
 
-The target reader is one of the lead developers/maintainers of a lesson under active development e.g. in [The Carpentries Incubator](https://github.com/carpentries-incubator/).
+The target reader is one of the lead developers/Maintainers of a lesson under active development e.g. in [The Carpentries Incubator](https://github.com/carpentries-incubator/).
 They should already have a clear idea of the target audience and main learning objectives for their lesson, even if they haven't started writing the actual material yet.
 They may be planning to teach the lesson for the first time, or have recently taught it for the first time, and now want to improve the lesson material based on feedback collected when teaching.
 

--- a/source/resources/workshops/checklists.md
+++ b/source/resources/workshops/checklists.md
@@ -6,98 +6,98 @@ A workshop host contacts The Carpentries Core Team about running a workshop. The
 
 **Before the workshop, the host will**
 
-1. Decide on the [Software Carpentry](https://software-carpentry.org/lessons/), [Data Carpentry](http://www.datacarpentry.org/lessons/), or [Library Carpentry](https://librarycarpentry.org/lessons/) curriculum that would best serve your learners
+1. Decide on the [Data Carpentry](http://www.datacarpentry.org/lessons/), [Library Carpentry](https://librarycarpentry.org/lessons/), or [Software Carpentry](https://software-carpentry.org/lessons/) curriculum that would best serve your learners.
 1. Fill out the [workshop request form](https://amy.carpentries.org/forms/workshop/).
-1. Work with The Carpentries Workshop Administration Team to set dates and location for your workshop, unless your workshop is virtual.
+1. Work with The Carpentries Workshops and Instruction Team to set dates and location for your workshop, unless your workshop is virtual.
     * Be sure to account for other events and programs at your site that may affect room availability and participant availability.
     * Ensure your location is [accessible](workshop_needs.md#accessibility).
-1. Recruit helpers to join your workshop. They do not need to be directly connected with The Carpentries. They do need basic knowledge of the tools we teach and enthusiasm to help others learn.  We recommend 1 helper for every 8-10 students, not counting the two instructors.
-1. Advertise your workshop. For Centrally-organised workshops the Workshop Administration Team can help by creating an Eventbrite registration page.
-1. Decide if you want to charge a workshop fee. Even a small fee can greatly reduce the no-show rate. If the Workshop Administration Team creates an Eventbrite registration page, The Carpentries can collect this fee via Eventbrite and use it to offset your workshop fee.
+1. Recruit helpers to join your workshop. They do not need to be directly connected with The Carpentries. They do need basic knowledge of the tools we teach and enthusiasm to help others learn.  We recommend 1 helper for every 8-10 students, not counting the two Instructors.
+1. Advertise your workshop. For Centrally-Organised workshops the Workshops and Instruction Team can help by creating an Eventbrite registration page.
+1. Decide if you want to charge a workshop fee. Even a small fee can greatly reduce the no-show rate. If the Workshops and Instruction Team creates an Eventbrite registration page, The Carpentries can collect this fee via Eventbrite and use it to offset your workshop fee.
 1. Work with The Carpentries Operations Manager to make arrangements to pay the workshop fee (only for Centrally-Organised workshops). This includes being sure vendor forms or other documentation are in place. The actual invoice will be issued after the workshop is complete.
-1. Make travel arrangements for visiting instructors (or communicate process to reimburse them for expenses) if the workshop is in person
-1. Get emergency contact information for instructors in case of last minute changes
-1. Arrange for [required materials and equipment](workshop_needs.md)
+1. Make travel arrangements for visiting Instructors (or communicate process to reimburse them for expenses) if the workshop is in person.
+1. Get emergency contact information for Instructors in case of last minute changes.
+1. Arrange for [required materials and equipment](workshop_needs.md).
 1. Arrange for coffee, snacks, and/or lunch. We all learn better with fuel!
-1. Email learners to remind them of workshop location, timing, pre-workshop survey and software installation requirements
-1. Organise a meetup with the instructors the day before the workshop if the workshop is in person, or sooner if the workshop is virtual.  While this is not always possible, it is useful for the host and instructors to get to know each other. This can be over coffee, dinner, or anything else that works for your team.
+1. Email learners to remind them of workshop location, timing, pre-workshop survey and software installation requirements.
+1. Organise a meetup with the Instructors the day before the workshop if the workshop is in person, or sooner if the workshop is virtual.  While this is not always possible, it is useful for the host and Instructors to get to know each other. This can be over coffee, dinner, or anything else that works for your team.
 
 **During the workshop, the host will**
 
-1. Meet the instructors and learners
-1. Ensure that the room is set up with all [necessary materials and equipment](workshop_needs.md)
-1. Periodically check in on the class to be sure things are running smoothly
+1. Meet the Instructors and learners.
+1. Ensure that the room is set up with all [necessary materials and equipment](workshop_needs.md).
+1. Periodically check in on the class to be sure things are running smoothly.
 
 **After the workshop, the host will**
 
-1. Collect workshop attendance
-1. Send attendance and any other feedback to The Carpentries Workshop Administration Team
-1. Pay the workshop fee (only for Centrally-Organised workshops)
-1. Reimburse the instructors
+1. Collect workshop attendance.
+1. Send attendance and any other feedback to The Carpentries Workshops and Instruction Team.
+1. Pay the workshop fee (only for Centrally-Organised workshops).
+1. Reimburse the Instructors.
 
 ### Billing Guidelines
 Payment for workshops is generally due 30 days after the invoice is issued.
 
-Invoices overdue 4 or more months may lead to the cessation of work on current activities involving the organisation to whom the overdue invoice was issued until the payment process is addressed.
+Invoices overdue four or more months may lead to the cessation of work on current activities involving the organisation to whom the overdue invoice was issued until the payment process is addressed.
 
 
 ## Instructor Checklist
 
-The Workshop Administration Team will introduce workshop hosts and instructors.
+The Workshops and Instruction Team will introduce workshop hosts and Instructors.
 
-**Before the workshop, instructors will**
+**Before the workshop, Instructors will**
 
-1. Decide on the order of the lessons and who will teach what modules
-1. Set up the workshop website using the [workshop template](https://github.com/carpentries/workshop-template) and send it to The Carpentries Workshop Administration Team.  Detailed instructions are in this repo's [README](https://github.com/carpentries/workshop-template#workshop-template).
-1. Create a collaborative document for the workshop (e.g. an [Etherpad](https://pad.carpentries.org/))
-1. Assist the host in recruiting helpers if possible
-1. Assist the host in ensuring the workshop location is accessible
-1. Share emergency contact information with host in case of last minute changes
-1. Practice teaching the material
-1. Remind the host of the [necessary equipment](workshop_needs.md)
-1. Join a [community discussion](https://pad.carpentries.org/community-discussions)
-1. Confirm criteria for reimbursement (*per diem* or save receipts)
+1. Decide on the order of the lessons and who will teach what modules.
+1. Set up the workshop website using the [workshop template](https://github.com/carpentries/workshop-template) and send it to The Carpentries Workshops and Instruction Team. Detailed instructions are in this repo's [README](https://github.com/carpentries/workshop-template#workshop-template).
+1. Create a collaborative document for the workshop (e.g. an [Etherpad](https://pad.carpentries.org/)).
+1. Assist the host in recruiting helpers, if possible.
+1. Assist the host in ensuring the workshop location is accessible.
+1. Share emergency contact information with the host in case of last minute changes.
+1. Practice teaching the material.
+1. Remind the host of the [necessary equipment](workshop_needs.md).
+1. Join a [community discussion](https://pad.carpentries.org/community-discussions).
+1. Confirm criteria for reimbursement (*per diem* or save receipts).
 
-**During the workshop, instructors will**
+**During the workshop, Instructors will**
 
-1. Review Code of Conduct with learners
-1. Remind learners to use sticky notes to give feedback
-1. Get feedback at lunch and end of each day using minute cards
-1. Support host in collecting attendee names and emails
-1. Send out the post-workshop survey at the very end of the workshop
+1. Review Code of Conduct with learners.
+1. Remind learners to use sticky notes to give feedback.
+1. Get feedback at lunch and end of each day using minute cards.
+1. Support the host in collecting attendee names and emails.
+1. Send out the post-workshop survey at the very end of the workshop.
 
-**After the workshop, instructors will**
+**After the workshop, Instructors will**
 
-1. Remind the host to send workshop attendance data to The Carpentries Workshop Administration Team
-1. Submit receipts for reimbursement
-1. Send their own feedback to the Workshop Administration Team including any configuration problems
-1. Take part in a [community discussion](https://pad.carpentries.org/community-discussions)
-1. Report any lesson errors or suggest improvements on GitHub or by email to The Carpentries Workshop Administration Team
+1. Remind the host to send workshop attendance data to The Carpentries Workshops and Instruction Team.
+1. Submit receipts for reimbursement.
+1. Send their own feedback to the Workshops and Instruction Team including any configuration problems.
+1. Take part in a [community discussion](https://pad.carpentries.org/community-discussions).
+1. Report any lesson errors or suggest improvements on GitHub or by email to The Carpentries Workshops and Instruction Team.
 
 ## Helper Checklist
 
-Helpers are often recruited from the local community at the host site to support Carpentries workshops.  Helpers support learners one-on-one if they are stuck installing software, understanding a certain line of code, or any other parts of the learning process.
+Helpers are often recruited from the local community at the host site to support Carpentries workshops. Helpers support learners one-on-one if they are stuck installing software, understanding a certain line of code, or any other parts of the learning process.
 
 **Before a workshop, helpers will**
 
-1. Introduce themselves to the instructors, letting them know any particular areas of expertise
-1. Review the curriculum the instructors will be teaching
-1. Review the software installation instructions to be prepared to troubleshoot with learners
-1. Make sure the instructors have listed you on the workshop website
+1. Introduce themselves to the Instructors, letting them know any particular areas of expertise.
+1. Review the curriculum the Instructors will be teaching.
+1. Review the software installation instructions to be prepared to troubleshoot with learners.
+1. Make sure the Instructors have listed you on the workshop website.
 
 
 **During the workshop, helpers will**
 
-1. Help learners with setup problems or anywhere else they get stuck
-1. Monitor room for anyone who may need help.  Learners may put up a red sticky note or indicate in other ways that they are stuck.
-1. Monitor any questions that come up on the collaborative document and answer them or remind the instructor about them during a break.
+1. Help learners with setup problems or anywhere else they get stuck.
+1. Monitor room for anyone who may need help. Learners may put up a red sticky note or indicate in other ways that they are stuck.
+1. Monitor any questions that come up on the collaborative document and answer them or remind the Instructor about them during a break.
 
 **After the workshop, helpers will**
 
-1. Send their own feedback to the instructors and the Workshop Administration Team including any configuration problems
-1. Consider applying to become a certified Carpentries instructor
+1. Send their own feedback to the Instructors and the Workshops and Instruction Team including any configuration problems.
+1. Consider applying to become a certified Carpentries Instructor.
 
-**Teaching Rules:**  
+## Teaching Rules  
 
 **Rule #1: Be kind**
 
@@ -126,21 +126,21 @@ Avoid saying things like:
 - Negative things about any applications or OS (Word, Excel, Windows, Mac, GUI): No tool is perfect, and this kind of disdain is not productive or conducive to the learning process.
 
 
-**Code of Conduct (Summary View)**  
+### Code of Conduct (Summary View)  
 
 >We are dedicated to providing a welcoming and supportive environment for all people, regardless of background or identity. By participating in this community, participants accept to abide by The Carpentries’ Code of Conduct and accept the procedures by which any Code of Conduct incidents are resolved. Any form or behaviour to exclude, intimidate, or cause discomfort is a violation of the Code of Conduct. In order to foster a positive and professional learning environment we encourage the following kinds of behaviours in all platforms and events:
 >
-- Use welcoming and inclusive language
-- Be respectful of different viewpoints and experiences
-- Gracefully accept constructive criticism
-- Focus on what is best for the community
-- Show courtesy and respect towards other community members
+- Use welcoming and inclusive language.
+- Be respectful of different viewpoints and experiences.
+- Gracefully accept constructive criticism.
+- Focus on what is best for the community.
+- Show courtesy and respect towards other community members.
 >
 If you believe someone is violating the Code of Conduct, we ask that you report it to The Carpentries Code of Conduct Committee completing [this form](https://goo.gl/forms/KoUfO53Za3apOuOK2), who will take the appropriate action to address the situation.
 
 
-More info can be found here: {{'[Code of Conduct]({})'.format(code_of_conduct)}}
+More info can be found here: {{'[Code of Conduct]({})'.format(code_of_conduct)}}.
 
 ## Email Templates
 
-Use [these](email_templates.md) templated emails for communicating with the learners
+Use [these](email_templates.md) templated emails for communicating with the learners.

--- a/source/resources/workshops/checklists.md
+++ b/source/resources/workshops/checklists.md
@@ -7,10 +7,10 @@ A workshop host contacts The Carpentries Core Team about running a workshop. The
 **Before the workshop, the host will**
 
 1. Decide on the [Software Carpentry](https://software-carpentry.org/lessons/), [Data Carpentry](http://www.datacarpentry.org/lessons/), or [Library Carpentry](https://librarycarpentry.org/lessons/) curriculum that would best serve your learners
-1. Fill out the [workshop request form](https://amy.carpentries.org/forms/workshop/)
-1. Work with The Carpentries Workshop Administration Team to set dates and location for your workshop, unless your workshop is virtual
-    * Be sure to account for other events and programs at your site that may affect room availability and participant availability
-    * Ensure your location is [accessible](workshop_needs.md#accessibility)
+1. Fill out the [workshop request form](https://amy.carpentries.org/forms/workshop/).
+1. Work with The Carpentries Workshop Administration Team to set dates and location for your workshop, unless your workshop is virtual.
+    * Be sure to account for other events and programs at your site that may affect room availability and participant availability.
+    * Ensure your location is [accessible](workshop_needs.md#accessibility).
 1. Recruit helpers to join your workshop. They do not need to be directly connected with The Carpentries. They do need basic knowledge of the tools we teach and enthusiasm to help others learn.  We recommend 1 helper for every 8-10 students, not counting the two instructors.
 1. Advertise your workshop. For Centrally-organised workshops the Workshop Administration Team can help by creating an Eventbrite registration page.
 1. Decide if you want to charge a workshop fee. Even a small fee can greatly reduce the no-show rate. If the Workshop Administration Team creates an Eventbrite registration page, The Carpentries can collect this fee via Eventbrite and use it to offset your workshop fee.

--- a/source/resources/workshops/email_templates.md
+++ b/source/resources/workshops/email_templates.md
@@ -10,7 +10,7 @@ Hi [ person name ],
 
 I am organising a local [ Data/Library/Software ] Carpentry workshop for [ estimated month/season of workshop ].  The Carpentries is a 501c3 non-profit organisation. They teach skills that are immediately useful for researchers, using lessons and datasets that allow researchers to quickly apply what they have learned to their own work. I am really excited about using the [ Data/Library/Software ] Carpentry curriculum here to help our [graduate students/Core Team/faculty - your target audience] become more efficient in their research.
 
-I have completed instructor training for The Carpentries and am certified to teach their materials. To lead a workshop, I will need at least one (preferably two) co-instructors to help out in teaching the material. The workshops are two days long and instructors usually switch every half day. I am planning to cover [ your workshop topics ] and was hoping you could teach the [ topic ] section of the workshop. The Carpentries provides ready-to-go lesson materials, so we would not need to develop anything from scratch. If you are interested, you can review the materials for [ topic ] here [ link to lesson ] and the rest of the curricular materials here [link to http://www.datacarpentry.org/lessons/ or https://software-carpentry.org/lessons/ or https://librarycarpentry.org/lessons/].
+I have completed Instructor Training for The Carpentries and am certified to teach their materials. To lead a workshop, I will need at least one (preferably two) co-instructors to help out in teaching the material. The workshops are two days long and instructors usually switch every half day. I am planning to cover [ your workshop topics ] and was hoping you could teach the [ topic ] section of the workshop. The Carpentries provides ready-to-use lesson materials, so we would not need to develop anything from scratch. If you are interested, you can review the materials for [ topic ] here [ link to lesson ] and the rest of the curricular materials here [link to http://www.datacarpentry.org/lessons/ or https://software-carpentry.org/lessons/ or https://librarycarpentry.org/lessons/].
 
 I am excited to teach  a workshop here and think it will be very helpful to our [ target audience ]. If you are interested in being a co-instructor, please let me know and we can get together and plan. Let me know if you know anyone else who might be interested and able to help out with the [ topic ] part of the workshop.
 
@@ -36,7 +36,7 @@ Best,
 [ sender name ]
 
 
-### Advertising your workshop  
+### Advertising your Workshop  
 
 Subject: Carpentries workshop at [ site name ]  
 
@@ -60,7 +60,7 @@ The target audience is learners who have little to no prior computational experi
 
 Space is limited and it will likely fill quickly. [ Add sentence about whether workshop is free or if there is a fee. ]. Here is a registration link [ link to your registration page ], and the workshop webpage [ link to your workshop webpage ] for more information. Questions? Send email to [ email contact ].
 
-We hope you will sign up! .
+We hope you will sign up!
 
 Best,
 
@@ -106,7 +106,7 @@ Thanks for making yourselves available to help with the [ workshop name ] worksh
  
 The workshop is being held at [ add location and directions ]. The teaching component will be [ start to finish time ]. Please arrive at the venue at [ briefing time ] for a briefing – we will go through the schedule for the day and make sure we all have an understanding of the goals for the day. We want to ensure the learners optimise their time with us. 
  
-The material we will be teaching is available at: [ add workshop webpage ]. Please review it prior to the workshop and review  the Code of Conduct for The Carpentries workshops that we will be abiding by: {{ code_of_conduct }}
+The material we will be teaching is available at: [ add workshop webpage ]. Please review it prior to the workshop and review  the Code of Conduct for The Carpentries workshops that we will be abiding by: {{ code_of_conduct }}.
  
 [ Say if you will be providing coffee, snacks, and/or lunch. Include time of lunch break if not providing lunch ]. Please bring a drink bottle and/or a reusable cup so we can reduce waste.
  
@@ -120,11 +120,12 @@ Best,
 ### Email Learners after Workshop  
 
 Hello,
+
 Thank you for attending our [ Data/Library/Software ] Carpentry workshop. We hope that you had fun and learned a lot of useful skills. 
 
 Please be sure to complete our post-workshop survey [ link to survey ]. Your answers are essential to allow us to continuously improve our workshops for future learners. 
 
-If you have any other feedback about the workshop, or would like to get involved in The Carpentries community, please contact us (mailto:team@carpentries.org). You can also join The Carpentries Discussion mailing list (https://carpentries.topicbox.com/groups/discuss), follow us on Mastodon (hachyderm.io/@thecarpentries), and get involved with lesson development on GitHub ( https://github.com/datacarpentry and https://github.com/swcarpentry/ ). 
+If you have any other feedback about the workshop, or would like to get involved in The Carpentries community, please contact us (team@carpentries.org). You can also join The Carpentries Discussion mailing list (https://carpentries.topicbox.com/groups/discuss), follow us on Mastodon (hachyderm.io/@thecarpentries) or BlueSky (bsky.app/profile/carpentries.carpentries.org) or LinkedIn (linkedin.com/company/the-carpentries/), and get involved with lesson development on GitHub ( https://github.com/datacarpentry and https://github.com/swcarpentry/ ). 
 
 The Carpentries is is excited to support you as you  continue to develop your data analysis skills!
 

--- a/source/resources/workshops/genomics_policy.md
+++ b/source/resources/workshops/genomics_policy.md
@@ -5,7 +5,7 @@ Your use of Amazon Web Services (AWS) instances provided by The Carpentries for 
 ## Submitting a Genomics Workshop
 
 1. Self-Organised Data Carpentry Genomics workshops in which organisers would like The Carpentries to provide AWS instances must be submitted using the Self-Organised {{'[workshop submission form]({}/forms/self-organised/)'.format(amy_link)}} at least five weeks before the workshop start date. Workshops submitted less than five weeks in advance will not be provided instances.  
-2. Centrally-Organised Data Carpentry Genomics workshops should be submitted using the {{'[Centrally-Organised workshop request form]({}/forms/request_workshop/)'.format(amy_link)}}, following the timeline previously outlined on the {{"[Carpentries website]({}/workshops/host-workshop/#request-a-centrally-organised-workshop)".format(carpentries_website)}}.
+2. Centrally-Organised Data Carpentry Genomics workshops should be submitted using the {{'[Centrally-Organised workshop request form]({}/forms/request_workshop/)'.format(amy_link)}}, following the timeline outlined on the {{"[Carpentries website]({}/workshops/host-workshop/#request-a-centrally-organised-workshop)".format(carpentries_website)}}.
 
 ## Pricing
 
@@ -33,7 +33,7 @@ Your use of Amazon Web Services (AWS) instances provided by The Carpentries for 
 1. AWS instances will be created by a member of the Workshops and Instruction Team according to the pricing option chosen in your workshop submission.   
 2. Once the invoice has been processed by CxORE, the number of AWS instances cannot be changed.  
 3. Refunds will **not** be issued for any AWS instances that were provided but not used in a workshop.   
-4. Details of test AWS instances for Instructors and Helpers will be sent up to seven days in advance of the workshop start date and details of the remaining AWS instances will be sent the day before the workshop start date.   
+4. Details of test AWS instances for Instructors and helpers will be sent up to seven days in advance of the workshop start date and details of the remaining AWS instances will be sent the day before the workshop start date.   
 5. All AWS instances will be closed one day after the workshop end date. 
 
 ## Discounted Workshops

--- a/source/resources/workshops/index.md
+++ b/source/resources/workshops/index.md
@@ -1,16 +1,16 @@
 # Workshop Resources 
 
-[Workshop Checklists](checklists.md): Best practices for planning a Carpentries workshop for your role as a Host, Instructor, or helper
+[Workshop Checklists](checklists.md): Best practices for planning a Carpentries workshop for your role as a host, Instructor, or helper.
 
-[Resources for Online Workshops](resources_for_online_workshops.md): A collection of tips and best practices for teaching workshops online
+[Resources for Online Workshops](resources_for_online_workshops.md): A collection of tips and best practices for teaching workshops online.
 
-[Creating a Workshop Website Demonstration](https://drive.google.com/file/d/1kGmy9oUs7jR_k3qPzAgmrSRmD6M_j04L/view?usp=sharing): Step by step video on how to create a workshop website
+[Creating a Workshop Website Demonstration](https://drive.google.com/file/d/1kGmy9oUs7jR_k3qPzAgmrSRmD6M_j04L/view?usp=sharing): Step by step video on how to create a Carpentries workshop website.
 
 [Email Templates](email_templates.md): Pre-written text to advertise your workshop, recruit helpers, email learners, and more! 
 
-[AMY Community Users Guide](https://carpentries.github.io/amy/users_guide/community_index/): Information for accessing your AMY profile
+[AMY Community Users Guide](https://carpentries.github.io/amy/users_guide/community_index/): Information for accessing your AMY profile.
 
-[Genomics Workshops Terms of Agreement](genomics_policy.md): Policy about setting up AWS instances for Data Carpentry Genomics workshops
+[Genomics Workshops Terms of Agreement](genomics_policy.md): Policy about setting up AWS instances for Data Carpentry Genomics workshops.
 
-For more resources, please visit the Additional Resources section of the [Instructor Tip Sheet](/resources/general/tip-sheets.md)
+For more resources, please visit the Additional Resources section of the [Instructor Tip Sheet](/resources/general/tip-sheets.md).
 


### PR DESCRIPTION
Updates in this PR pertain to the pages listed on the [Workshops Resources](https://docs.carpentries.org/resources/workshops/) in the Handbook. 
