### PR TITLE
remove link to deprecated resources

### DIFF
--- a/source/resources/workshops/resources_for_online_workshops.md
+++ b/source/resources/workshops/resources_for_online_workshops.md
@@ -78,7 +78,6 @@ Review these if you are looking to write about your teaching experiences:
 ## Other Relevant Resources
 
 - UK Software Sustainability Institute's [guidance for running online training events](https://carpentries.org/blog/2020/07/software-sustainability-institute-online-training-guidance/).
-- Laura Czerniewicz on 15 March, [What we learnt from “going online” during university shutdowns in South Africa](https://philonedtech.com/what-we-learnt-from-going-online-during-university-shutdowns-in-south-africa/).
 - Greg Wilson on 24 March, [Teaching Online at Short Notice](https://resources.rstudio.com/webinars/teaching-online-at-short-notice).
 - [Strategies for addressing unequal technological access from the University of Cape Town](https://docs.google.com/document/d/1541zKh3UCtVKAkdITkYHWu4GXVW1lGWEdWFE-I8PeXk/edit?usp=sharing).
 - Lex Nederbragt on 2 April, [Scaling participatory live coding in an undergraduate computational biology course](https://lexnederbragt.com/blog/2020-04-02-scaling-live-coding).


### PR DESCRIPTION
Instructor Trainers were briefly using `forum.carpentries.org` - removing this item because it has long been deprecated.  

This PR also removes other resources with broken links.

