### PR TITLE
Shorten definition of newsletter

### DIFF
--- a/source/resources/general/glossary.md
+++ b/source/resources/general/glossary.md
@@ -315,7 +315,7 @@ Member Organisation
 ```{glossary}
 
 Newsletter
-    communication sent to an opt-in mailing list each month, featuring community news and announcements and including important updates from The Carpentries committees, task forces and programs, job postings, and related information for our community from other organisations; refer to {term}`Carpentries Clippings<carpentries clippings>`.
+    refer to {term}`Carpentries Clippings<carpentries clippings>`.
 
 ```
 


### PR DESCRIPTION
I think the definition of _Newsletter_ is redundant with that of _Carpentries Clippings_, especially since we are already linking to the latter. This PR removes the additional definition of _Newsletter_, leaving only the link to refer to the other one.

I don't feel strongly about this change, so feel free to close the PR if you disagree!