### PR TITLE
Add crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,27 +1,37 @@
 preserve_hierarchy: true
 
 files:
-  - source: /episodes/*.Rmd
-    dest: /episodes/%file_name%.md
-    type: md
-    translation: /locale/%two_letters_code%/episodes/%original_file_name%
+  - source: /source/handbooks/*.md
+    translation: /locale/%two_letters_code%/handbooks/%original_file_name%
     update_option: update_as_unapproved
-  - source: /episodes/*.md
-    translation: /locale/%two_letters_code%/episodes/%original_file_name%
+
+  - source: /source/policies/*.md
+    translation: /locale/%two_letters_code%/policies/%original_file_name%
     update_option: update_as_unapproved
-  - source: /instructors/*.md
-    translation: /locale/%two_letters_code%/instructors/%original_file_name%
+  - source: /source/policies/coc/*.md
+    translation: /locale/%two_letters_code%/policies/coc/%original_file_name%
     update_option: update_as_unapproved
-  - source: /learners/*.md
-    translation: /locale/%two_letters_code%/learners/%original_file_name%
+
+  - source: /source/resources/*.md
+    translation: /locale/%two_letters_code%/resources/%original_file_name%
     update_option: update_as_unapproved
-  - source: /profiles/*.md
-    translation: /locale/%two_letters_code%/profiles/%original_file_name%
+  - source: /source/resources/communications/*.md
+    translation: /locale/%two_letters_code%/resources/communications/%original_file_name%
     update_option: update_as_unapproved
+  - source: /source/resources/curriculum/*.md
+    translation: /locale/%two_letters_code%/resources/curriculum/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /source/resources/general/*.md
+    translation: /locale/%two_letters_code%/resources/general/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /source/resources/instructor-training/*.md
+    translation: /locale/%two_letters_code%/resources/instructor-training/%original_file_name%
+    update_option: update_as_unapproved
+  - source: /source/resources/workshops/*.md
+    translation: /locale/%two_letters_code%/resources/workshops/%original_file_name%
+    update_option: update_as_unapproved
+
   - source: /CODE_OF_CONDUCT.md
-    translation: /locale/%two_letters_code%/%original_file_name%
-    update_option: update_as_unapproved
-  - source: /config.yaml
     translation: /locale/%two_letters_code%/%original_file_name%
     update_option: update_as_unapproved
   - source: /CONTRIBUTING.md
@@ -33,10 +43,3 @@ files:
   - source: /README.md
     translation: /locale/%two_letters_code%/%original_file_name%
     update_option: update_as_unapproved
-  - source: /index.md
-    translation: /locale/%two_letters_code%/%original_file_name%
-    update_option: update_as_unapproved
-  - source: /links.md
-    translation: /locale/%two_letters_code%/%original_file_name%
-    update_option: update_as_unapproved
-


### PR DESCRIPTION
Adds support for configuring CrowdIn translations via the crowdin.yml file.
